### PR TITLE
Add manual physics stepping via Engine.physics_iteration (Phase 1)

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -436,6 +436,14 @@ bool Engine::is_embedded_in_editor() const {
 	return embedded_in_editor;
 }
 
+void Engine::set_manual_physics_iteration_callback(ManualPhysicsIterationCallback p_callback) {
+	_manual_physics_iteration_callback = p_callback;
+}
+
+Engine::ManualPhysicsIterationCallback Engine::get_manual_physics_iteration_callback() const {
+	return _manual_physics_iteration_callback;
+}
+
 Engine::Engine() {
 	singleton = this;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -42,6 +42,11 @@ class TypedArray;
 
 class Engine {
 public:
+	// Callback registered by Main at startup so core_bind::Engine::physics_iteration
+	// can invoke the per-physics-tick body without a core→main reverse dependency.
+	// Returns true iff the main loop requested termination during that tick.
+	typedef bool (*ManualPhysicsIterationCallback)(double p_step, double p_time_scale);
+
 	struct Singleton {
 		StringName name;
 		Object *ptr = nullptr;
@@ -107,6 +112,8 @@ private:
 	bool frame_server_synced = false;
 
 	bool freeze_time_scale = false;
+
+	ManualPhysicsIterationCallback _manual_physics_iteration_callback = nullptr;
 
 protected:
 	void _update_time_scale();
@@ -223,6 +230,11 @@ public:
 	void set_freeze_time_scale(bool p_frozen);
 	void set_embedded_in_editor(bool p_enabled);
 	bool is_embedded_in_editor() const;
+
+	// Called by Main at startup to register the physics tick body so core_bind
+	// can invoke it without a core→main dependency.
+	void set_manual_physics_iteration_callback(ManualPhysicsIterationCallback p_callback);
+	ManualPhysicsIterationCallback get_manual_physics_iteration_callback() const;
 
 	Engine();
 	virtual ~Engine();

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1891,6 +1891,19 @@ void ClassDB::_bind_methods() {
 
 ////// Engine //////
 
+bool Engine::physics_iteration(double p_delta) {
+	ERR_FAIL_COND_V_MSG(
+			!GLOBAL_GET("physics/common/manual_physics_stepping"),
+			false,
+			"physics_iteration() requires ProjectSettings.physics/common/manual_physics_stepping = true.");
+
+	::Engine::ManualPhysicsIterationCallback cb = ::Engine::get_singleton()->get_manual_physics_iteration_callback();
+	ERR_FAIL_NULL_V_MSG(cb, false, "physics_iteration() called before the main loop is initialized.");
+
+	const double time_scale = ::Engine::get_singleton()->get_effective_time_scale();
+	return cb(p_delta, time_scale);
+}
+
 void Engine::set_physics_ticks_per_second(int p_ips) {
 	::Engine::get_singleton()->set_physics_ticks_per_second(p_ips);
 }
@@ -2097,6 +2110,8 @@ void Engine::get_argument_options(const StringName &p_function, int p_idx, List<
 #endif
 
 void Engine::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("physics_iteration", "delta"), &Engine::physics_iteration);
+
 	ClassDB::bind_method(D_METHOD("set_physics_ticks_per_second", "physics_ticks_per_second"), &Engine::set_physics_ticks_per_second);
 	ClassDB::bind_method(D_METHOD("get_physics_ticks_per_second"), &Engine::get_physics_ticks_per_second);
 	ClassDB::bind_method(D_METHOD("set_max_physics_steps_per_frame", "max_physics_steps"), &Engine::set_max_physics_steps_per_frame);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -574,6 +574,8 @@ protected:
 
 public:
 	static Engine *get_singleton() { return singleton; }
+	bool physics_iteration(double p_delta);
+
 	void set_physics_ticks_per_second(int p_ips);
 	int get_physics_ticks_per_second() const;
 

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -274,6 +274,40 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="physics_iteration">
+			<return type="bool" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Advances the physics simulation by exactly one tick of [param delta] seconds. Runs [method Node._physics_process], emits [signal SceneTree.physics_frame], updates navigation servers, flushes the message queue, and steps the [PhysicsServer2D] and [PhysicsServer3D] — the same sequence the automatic physics loop executes each tick. Also advances [method get_physics_frames] by [code]1[/code] and consumes input edges (see [method Input.is_action_just_pressed]).
+				Returns [code]true[/code] if the main loop requested termination during this tick (equivalent to [method SceneTree.quit] being called inside [method Node._physics_process]), matching the exit signal the automatic loop would have returned. Returns [code]false[/code] otherwise.
+				[b]Note:[/b] This method requires [member ProjectSettings.physics/common/manual_physics_stepping] to be [code]true[/code]. If that setting is [code]false[/code], an error is pushed, the call is a no-op, and [code]false[/code] is returned.
+				[b]Note:[/b] In Phase 1, enabling this setting does [i]not[/i] disable the automatic physics loop. Manual ticks are additive. Full loop-ownership transfer from script is out of scope until a later phase.
+				[b]Note:[/b] Mixing automatic stepping with manual stepping in the same frame may produce unintended input-edge consumption. Hardening of mixed auto+manual edge cases is deferred to a later phase.
+				[codeblocks]
+				[gdscript]
+				# Sub-stepping: advance physics at a finer rate than the automatic tick.
+				func _process(delta):
+				    var N := 4
+				    for i in N:
+				        Engine.physics_iteration(delta / N)
+				[/gdscript]
+				[csharp]
+				// Sub-stepping: advance physics at a finer rate than the automatic tick.
+				public override void _Process(double delta)
+				{
+				    base._Process(delta);
+
+				    int n = 4;
+				    for (int i = 0; i &lt; n; i++)
+				    {
+				        Engine.Singleton.PhysicsIteration(delta / n);
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
+				See also [member ProjectSettings.physics/common/manual_physics_stepping].
+			</description>
+		</method>
 		<method name="register_script_language">
 			<return type="int" enum="Error" />
 			<param index="0" name="language" type="ScriptLanguage" />

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2686,6 +2686,11 @@
 			However, the game will appear to slow down if the rendering FPS is less than [code]1 / max_physics_steps_per_frame[/code] of [member physics/common/physics_ticks_per_second]. This occurs even if [code]delta[/code] is consistently used in physics calculations. To avoid this, increase [member physics/common/max_physics_steps_per_frame] if you have increased [member physics/common/physics_ticks_per_second] significantly above its default value.
 			[b]Note:[/b] This property is only read when the project starts. To change the maximum number of simulated physics steps per frame at runtime, set [member Engine.max_physics_steps_per_frame] instead.
 		</member>
+		<member name="physics/common/manual_physics_stepping" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enables manual physics stepping via [method Engine.physics_iteration]. When enabled, each call to [method Engine.physics_iteration] drives exactly one physics tick instead of — or in addition to — the automatic fixed-timestep loop.
+			When [code]false[/code] (the default), this setting has no effect and the automatic physics loop runs exactly as before; calling [method Engine.physics_iteration] with this setting off emits an error and does nothing.
+			[b]Note:[/b] Enabling this setting in Phase 1 does [i]not[/i] disable the automatic physics loop. Manual ticks are additive. Full automatic-loop suppression is deferred to a later phase.
+		</member>
 		<member name="physics/common/physics_interpolation" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the renderer will interpolate the transforms of objects (both physics and non-physics) between the last two transforms, so that smooth motion is seen even when physics ticks do not coincide with rendered frames. See also [method Node.reset_physics_interpolation].
 			[b]Note:[/b] Although this is a global setting, finer control of individual branches of the [SceneTree] is possible using [member Node.physics_interpolation_mode].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2246,6 +2246,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	Engine::get_singleton()->set_physics_ticks_per_second(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/physics_ticks_per_second", PROPERTY_HINT_RANGE, "1,1000,1"), 60));
 	Engine::get_singleton()->set_max_physics_steps_per_frame(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/max_physics_steps_per_frame", PROPERTY_HINT_RANGE, "1,100,1"), 8));
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "physics/common/manual_physics_stepping"), false);
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/common/physics_jitter_fix", PROPERTY_HINT_RANGE, "0,2,0.001,or_greater"), 0.5));
 	Engine::get_singleton()->set_max_fps(GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
 	if (max_fps >= 0) {
@@ -4431,6 +4432,10 @@ int Main::start() {
 
 	OS::get_singleton()->set_main_loop(main_loop);
 
+	// Register the physics tick body so core_bind::Engine::physics_iteration can
+	// invoke it without a core→main reverse dependency (spec D4).
+	Engine::get_singleton()->set_manual_physics_iteration_callback(&Main::physics_iteration_step);
+
 	SceneTree *sml = Object::cast_to<SceneTree>(main_loop);
 	if (sml) {
 #ifdef DEBUG_ENABLED
@@ -4910,6 +4915,107 @@ bool Main::is_iterating() {
 static uint64_t physics_process_max = 0;
 static uint64_t process_max = 0;
 static uint64_t navigation_process_max = 0;
+// Per-frame accumulators (largest step seen within the current frame).
+// Reset at the top of Main::iteration; also updated by physics_iteration_step
+// so the manual path has the same diagnostics as the automatic path.
+static uint64_t physics_process_ticks_last_frame = 0;
+static uint64_t navigation_process_ticks_last_frame = 0;
+
+// Runs exactly one physics tick. Extracted from Main::iteration's per-step loop body
+// so the same function is used by the automatic loop and by Engine.physics_iteration().
+// p_physics_step_ticks and p_navigation_process_ticks are per-frame accumulators
+// (largest-step tracking) passed in from the caller; they are updated in-place.
+// Returns true iff MainLoop::physics_process requested exit this tick.
+bool Main::physics_iteration_step(double p_physics_step, double p_time_scale) {
+	GodotProfileZone("Physics Step");
+	GodotProfileZoneGroupedFirst(_physics_zone, "setup");
+	if (Input::get_singleton()->is_agile_input_event_flushing()) {
+		Input::get_singleton()->flush_buffered_events();
+	}
+
+	Engine::get_singleton()->_in_physics = true;
+	Engine::get_singleton()->_physics_frames++;
+
+	uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
+
+	// Prepare the fixed timestep interpolated nodes BEFORE they are updated
+	// by the physics server, otherwise the current and previous transforms
+	// may be the same, and no interpolation takes place.
+	GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
+	OS::get_singleton()->get_main_loop()->iteration_prepare();
+
+#ifndef PHYSICS_3D_DISABLED
+	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
+	PhysicsServer3D::get_singleton()->sync();
+	PhysicsServer3D::get_singleton()->flush_queries();
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
+	PhysicsServer2D::get_singleton()->sync();
+	PhysicsServer2D::get_singleton()->flush_queries();
+#endif // PHYSICS_2D_DISABLED
+
+	GodotProfileZoneGrouped(_physics_zone, "physics_process");
+	if (OS::get_singleton()->get_main_loop()->physics_process(p_physics_step * p_time_scale)) {
+#ifndef PHYSICS_3D_DISABLED
+		PhysicsServer3D::get_singleton()->end_sync();
+#endif // PHYSICS_3D_DISABLED
+#ifndef PHYSICS_2D_DISABLED
+		PhysicsServer2D::get_singleton()->end_sync();
+#endif // PHYSICS_2D_DISABLED
+
+		Engine::get_singleton()->_in_physics = false;
+		return true;
+	}
+
+#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+	uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
+
+#ifndef NAVIGATION_2D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
+	NavigationServer2D::get_singleton()->physics_process(p_physics_step * p_time_scale);
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
+	NavigationServer3D::get_singleton()->physics_process(p_physics_step * p_time_scale);
+#endif // NAVIGATION_3D_DISABLED
+
+	{
+		const uint64_t nav_elapsed = OS::get_singleton()->get_ticks_usec() - navigation_begin;
+		navigation_process_ticks_last_frame = MAX(navigation_process_ticks_last_frame, nav_elapsed); // keep the largest one for reference
+		navigation_process_max = MAX(nav_elapsed, navigation_process_max);
+	}
+
+	message_queue->flush();
+#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+
+#ifndef PHYSICS_3D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "3D physics");
+	PhysicsServer3D::get_singleton()->end_sync();
+	PhysicsServer3D::get_singleton()->step(p_physics_step * p_time_scale);
+#endif // PHYSICS_3D_DISABLED
+
+#ifndef PHYSICS_2D_DISABLED
+	GodotProfileZoneGrouped(_profile_zone, "2D physics");
+	PhysicsServer2D::get_singleton()->end_sync();
+	PhysicsServer2D::get_singleton()->step(p_physics_step * p_time_scale);
+#endif // PHYSICS_2D_DISABLED
+
+	message_queue->flush();
+
+	GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
+	OS::get_singleton()->get_main_loop()->iteration_end();
+
+	{
+		const uint64_t phys_elapsed = OS::get_singleton()->get_ticks_usec() - physics_begin;
+		physics_process_ticks_last_frame = MAX(physics_process_ticks_last_frame, phys_elapsed); // keep the largest one for reference
+		physics_process_max = MAX(phys_elapsed, physics_process_max);
+	}
+
+	Engine::get_singleton()->_in_physics = false;
+	return false;
+}
 
 // Return false means iterating further, returning true means `OS::run`
 // will terminate the program. In case of failure, the OS exit code needs
@@ -4938,11 +5044,11 @@ bool Main::iteration() {
 	Engine::get_singleton()->_process_step = process_step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;
 
-	uint64_t physics_process_ticks = 0;
 	uint64_t process_ticks = 0;
-#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-	uint64_t navigation_process_ticks = 0;
-#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+
+	// Reset per-frame physics timing accumulators (updated inside physics_iteration_step).
+	physics_process_ticks_last_frame = 0;
+	navigation_process_ticks_last_frame = 0;
 
 	frame += ticks_elapsed;
 
@@ -4964,88 +5070,10 @@ bool Main::iteration() {
 
 	GodotProfileZoneGrouped(_profile_zone, "physics");
 	for (int iters = 0; iters < advance.physics_steps; ++iters) {
-		GodotProfileZone("Physics Step");
-		GodotProfileZoneGroupedFirst(_physics_zone, "setup");
-		if (Input::get_singleton()->is_agile_input_event_flushing()) {
-			Input::get_singleton()->flush_buffered_events();
-		}
-
-		Engine::get_singleton()->_in_physics = true;
-		Engine::get_singleton()->_physics_frames++;
-
-		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
-
-		// Prepare the fixed timestep interpolated nodes BEFORE they are updated
-		// by the physics server, otherwise the current and previous transforms
-		// may be the same, and no interpolation takes place.
-		GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
-		OS::get_singleton()->get_main_loop()->iteration_prepare();
-
-#ifndef PHYSICS_3D_DISABLED
-		GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
-		PhysicsServer3D::get_singleton()->sync();
-		PhysicsServer3D::get_singleton()->flush_queries();
-#endif // PHYSICS_3D_DISABLED
-
-#ifndef PHYSICS_2D_DISABLED
-		GodotProfileZoneGrouped(_physics_zone, "PhysicsServer2D::sync");
-		PhysicsServer2D::get_singleton()->sync();
-		PhysicsServer2D::get_singleton()->flush_queries();
-#endif // PHYSICS_2D_DISABLED
-
-		GodotProfileZoneGrouped(_physics_zone, "physics_process");
-		if (OS::get_singleton()->get_main_loop()->physics_process(physics_step * time_scale)) {
-#ifndef PHYSICS_3D_DISABLED
-			PhysicsServer3D::get_singleton()->end_sync();
-#endif // PHYSICS_3D_DISABLED
-#ifndef PHYSICS_2D_DISABLED
-			PhysicsServer2D::get_singleton()->end_sync();
-#endif // PHYSICS_2D_DISABLED
-
-			Engine::get_singleton()->_in_physics = false;
+		if (physics_iteration_step(physics_step, time_scale)) {
 			exit = true;
 			break;
 		}
-
-#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
-
-#ifndef NAVIGATION_2D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
-		NavigationServer2D::get_singleton()->physics_process(physics_step * time_scale);
-#endif // NAVIGATION_2D_DISABLED
-#ifndef NAVIGATION_3D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
-		NavigationServer3D::get_singleton()->physics_process(physics_step * time_scale);
-#endif // NAVIGATION_3D_DISABLED
-
-		navigation_process_ticks = MAX(navigation_process_ticks, OS::get_singleton()->get_ticks_usec() - navigation_begin); // keep the largest one for reference
-		navigation_process_max = MAX(OS::get_singleton()->get_ticks_usec() - navigation_begin, navigation_process_max);
-
-		message_queue->flush();
-#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-
-#ifndef PHYSICS_3D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "3D physics");
-		PhysicsServer3D::get_singleton()->end_sync();
-		PhysicsServer3D::get_singleton()->step(physics_step * time_scale);
-#endif // PHYSICS_3D_DISABLED
-
-#ifndef PHYSICS_2D_DISABLED
-		GodotProfileZoneGrouped(_profile_zone, "2D physics");
-		PhysicsServer2D::get_singleton()->end_sync();
-		PhysicsServer2D::get_singleton()->step(physics_step * time_scale);
-#endif // PHYSICS_2D_DISABLED
-
-		message_queue->flush();
-
-		GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
-		OS::get_singleton()->get_main_loop()->iteration_end();
-
-		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
-		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
-
-		Engine::get_singleton()->_in_physics = false;
 	}
 
 	if (Input::get_singleton()->is_agile_input_event_flushing()) {
@@ -5108,7 +5136,7 @@ bool Main::iteration() {
 	AudioServer::get_singleton()->update();
 
 	if (EngineDebugger::is_active()) {
-		EngineDebugger::get_singleton()->iteration(frame_time, process_ticks, physics_process_ticks, physics_step);
+		EngineDebugger::get_singleton()->iteration(frame_time, process_ticks, physics_process_ticks_last_frame, physics_step);
 	}
 
 	frames++;

--- a/main/main.h
+++ b/main/main.h
@@ -77,6 +77,12 @@ public:
 	static void test_cleanup();
 	static int start();
 
+	// Runs exactly one physics tick: the body previously inlined in Main::iteration's
+	// physics for-loop. Returns true iff MainLoop::physics_process requested exit.
+	// Registered as a callback on ::Engine at startup so core_bind can invoke it
+	// without a core→main reverse dependency.
+	static bool physics_iteration_step(double p_physics_step, double p_time_scale);
+
 	static bool iteration();
 	static void force_redraw();
 


### PR DESCRIPTION
Part of [GH-1](https://github.com/nongvantinh/godot/issues/1) · Fixes [GH-3](https://github.com/nongvantinh/godot/issues/3)

## Summary

Phase 1 of the backend-agnostic physics control layer ([EPIC #1](https://github.com/nongvantinh/godot/issues/1)). Extracts the per-physics-tick body from `Main::iteration` into a single reusable static function `Main::physics_iteration_step(step, time_scale)` and exposes it to GDScript as `Engine.physics_iteration(delta) -> bool`, gated by a new project setting `physics/common/manual_physics_stepping` (default `false`). Both the automatic loop and the new manual path call the same extracted function, so the default path is **byte-for-byte unchanged** when the feature is off.

## What changed

- **`main/main.cpp` / `main/main.h`** — `Main::physics_iteration_step(double, double)` extracted from the per-tick `for`-loop body in `Main::iteration`; the automatic loop now calls it; a callback pointer to it is registered on `::Engine` at `Main::start` time (D4).
- **`core/config/engine.h` / `core/config/engine.cpp`** — `ManualPhysicsIterationCallback` typedef + `set_manual_physics_iteration_callback` / getter; member defaults `nullptr`. No `core → main` reverse dependency.
- **`core/core_bind.cpp` / `core/core_bind.h`** — `Engine::physics_iteration(double p_delta) -> bool` bound via `ClassDB`; guards on `manual_physics_stepping` setting (D3) and a null callback before invoking.
- **`doc/classes/Engine.xml`** — `physics_iteration` method doc with `[codeblocks]` (GDScript + C#), additive Phase-1 caveat, cross-ref to `manual_physics_stepping`.
- **`doc/classes/ProjectSettings.xml`** — `physics/common/manual_physics_stepping` member doc (type `bool`, default `false`).

## Key decisions (D1–D5)

| # | Decision | Rationale |
|---|---|---|
| D1 | Plain `bool manual_physics_stepping` — no enum | `AUTO`/`MANUAL`/`DRY_RUN` enum deferred to Phase 4 (#6); bool can be superseded with migration default |
| D2 | Returns main-loop quit/exit signal (`true` = termination requested) | Parity with `MainLoop::physics_process` return; manual driver can honour `get_tree().quit()` correctly |
| D3 | Setting off → `push_error` + no-op + `false` | Fail-fast surfaces misconfiguration; silent no-op hides setup errors during rollback/prediction bring-up |
| D4 | Body in `main/main.cpp`; reached from `core_bind` via function-pointer callback on `::Engine` | Avoids `core → main` reverse dependency and tick-body duplication in `core/config/engine.cpp` |
| D5 | Phase 1 inherits existing threading; `PhysicsServer3DWrapMT` work deferred to Phase 2 (#4) | Extracted function reuses the same `sync()/flush_queries()/end_sync()/step()` sequence the auto loop already drives |

## Acceptance criteria — final state

- ✅ AC-1 — `ProjectSettings.has_setting("physics/common/manual_physics_stepping")` true; type `bool`; default `false`
- ✅ AC-2 — `Engine.physics_iteration(delta)` callable from GDScript when setting enabled; returns `bool`
- ✅ AC-3 — One call advances `get_physics_frames()` by exactly 1; RigidBody transforms update
- ✅ AC-4 — Setting off → `push_error` emitted; frames unchanged; returns `false`
- ✅ AC-5 — N sub-steps advance `get_physics_frames()` by exactly N
- ✅ AC-6 — Bit-identical default-path regression: 60 auto ticks with setting off match `GH-1` baseline (`pos_y=5.333305 vel_y=-9.185307`)
- ✅ AC-7 — `_physics_process` quit signal: manual tick returns `true`, `end_sync` runs before `step`, `_in_physics=false` on exit
- ✅ AC-8 — Input-edge consumption: `is_action_just_pressed()` true on tick 1 only
- ✅ AC-9 — No server-stepping body in `core/config/engine.cpp`; `grep` clean
- ✅ AC-10 — 1361/1361 doctests pass; existing test suite green

## Verification (host build, incremental scons)

**Build:** clean compile, `bin/godot.linuxbsd.editor.dev.x86_64` produced. All 1361 doctests pass.

**AC-6 (byte-for-byte default-path regression):** deterministic headless scene (60 auto ticks, free-falling RigidBody3D) — baseline `GH-1` vs patched binary (setting off):
- Baseline:            `physics_frames=60  pos_y=5.333305  vel_y=-9.185307`
- Patched (off):       `physics_frames=60  pos_y=5.333305  vel_y=-9.185307`
- **Bit-identical** — default path unchanged.

**AC-4 (error + no-op when off):** `push_error` emitted, `get_physics_frames()` unchanged, returns `false`. Verified with headless GDScript harness.

**AC-1, AC-3, AC-5 (manual tick, sub-stepping):** with `manual_physics_stepping=true` — single call advances frames by 1; 4 sub-steps advance by 4. Verified with headless GDScript harness.

**AC-9 (no body duplication):** `grep` confirms zero PhysicsServer calls in `core/config/engine.cpp`.

**Reviewer:** ✅ Approve (iteration 2 — `[codeblocks]` parity fix) — 0 critical, 0 major, 0 minor.
**Security audit:** PASS — 0 critical/high blockers. See [security audit comment](https://github.com/nongvantinh/godot/pull/10#issuecomment-4633419051) for Medium (delta validation) and Info (re-entrancy, callback teardown) forward-notes.

## Operational notes

Setting-gated (`manual_physics_stepping` default `false`) — existing projects see **no behaviour change** until they opt in. Rollout: merge to `GH-1`, rebuild the custom Godot binary via `Misc/godot-build-scripts/`. Rollback: revert the `GH-1` merge; additive + gated, no project data affected.

**Note:** In Phase 1, enabling `manual_physics_stepping` makes manual ticks *additive* — the automatic loop continues to run unless the project also disables it. Full transfer of loop ownership to script is deferred to Phase 5 (#7).

## Follow-ups

- [ ] **[Medium — fast-follow]** Add `delta` finite/non-negative guard in `core/core_bind.cpp::Engine::physics_iteration` before invoking the manual-tick callback: `ERR_FAIL_COND_V(!Math::is_finite(p_delta) || p_delta < 0.0, false)` — surfaces on issue [GH-3](https://github.com/nongvantinh/godot/issues/3) (security audit finding)
- [ ] **[Phase 4 — #6]** Clear `manual_physics_iteration_callback` in `Main::cleanup` and null-guard `get_main_loop()` inside the step body — needed when isolated sims / lifecycle churn arrive in Phase 4
- [ ] **[Phase 2 — #4]** Narrow Jolt include-path addition in `SCsub` to test env only (Low security finding from Phase 0 audit)

## Links

- Ticket: [GH-3](https://github.com/nongvantinh/godot/issues/3)
- EPIC: [GH-1](https://github.com/nongvantinh/godot/issues/1)
- Spec: [GH-3 spec comment](https://github.com/nongvantinh/godot/issues/3#issuecomment-4632912955)
- ADR (Phase 1): posted as comment on [GH-1](https://github.com/nongvantinh/godot/issues/1) (see below)
- Security audit: [PR #10 comment](https://github.com/nongvantinh/godot/pull/10#issuecomment-4633419051)
