### PR TITLE
feat(physics): space_clone_state + FEATURE_STATE_CLONE + dry-run stepping (Phase 4)

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -45,7 +45,9 @@ public:
 	// Callback registered by Main at startup so core_bind::Engine::physics_iteration
 	// can invoke the per-physics-tick body without a core→main reverse dependency.
 	// Returns true iff the main loop requested termination during that tick.
-	typedef bool (*ManualPhysicsIterationCallback)(double p_step, double p_time_scale);
+	// p_dry_run: when true the tick must NOT advance get_physics_frames() or
+	// consume Input action edges (enforced by DEV_ASSERT inside the body).
+	typedef bool (*ManualPhysicsIterationCallback)(double p_step, double p_time_scale, bool p_dry_run);
 
 	struct Singleton {
 		StringName name;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1891,7 +1891,7 @@ void ClassDB::_bind_methods() {
 
 ////// Engine //////
 
-bool Engine::physics_iteration(double p_delta) {
+bool Engine::physics_iteration(double p_delta, bool p_dry_run) {
 	ERR_FAIL_COND_V_MSG(
 			!GLOBAL_GET("physics/common/manual_physics_stepping"),
 			false,
@@ -1901,7 +1901,7 @@ bool Engine::physics_iteration(double p_delta) {
 	ERR_FAIL_NULL_V_MSG(cb, false, "physics_iteration() called before the main loop is initialized.");
 
 	const double time_scale = ::Engine::get_singleton()->get_effective_time_scale();
-	return cb(p_delta, time_scale);
+	return cb(p_delta, time_scale, p_dry_run);
 }
 
 void Engine::set_physics_ticks_per_second(int p_ips) {
@@ -2110,7 +2110,7 @@ void Engine::get_argument_options(const StringName &p_function, int p_idx, List<
 #endif
 
 void Engine::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("physics_iteration", "delta"), &Engine::physics_iteration);
+	ClassDB::bind_method(D_METHOD("physics_iteration", "delta", "dry_run"), &Engine::physics_iteration, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("set_physics_ticks_per_second", "physics_ticks_per_second"), &Engine::set_physics_ticks_per_second);
 	ClassDB::bind_method(D_METHOD("get_physics_ticks_per_second"), &Engine::get_physics_ticks_per_second);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -574,7 +574,7 @@ protected:
 
 public:
 	static Engine *get_singleton() { return singleton; }
-	bool physics_iteration(double p_delta);
+	bool physics_iteration(double p_delta, bool p_dry_run = false);
 
 	void set_physics_ticks_per_second(int p_ips);
 	int get_physics_ticks_per_second() const;

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1585,6 +1585,18 @@ bool Input::is_agile_input_event_flushing() {
 	return agile_input_event_flushing;
 }
 
+uint64_t Input::get_action_edge_fingerprint() const {
+	// Sum all pressed/released physics-frame stamps across every tracked action.
+	// A flush that consumes or creates an action edge bumps one of these stamps,
+	// so the sum changes. Used only inside DEV_ASSERT in physics_iteration_step.
+	uint64_t sum = 0;
+	for (const KeyValue<StringName, ActionState> &kv : action_states) {
+		sum += kv.value.pressed_physics_frame;
+		sum += kv.value.released_physics_frame;
+	}
+	return sum;
+}
+
 void Input::set_agile_input_event_flushing(bool p_enable) {
 	agile_input_event_flushing = p_enable;
 }

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -474,6 +474,12 @@ public:
 #endif
 	void flush_buffered_events();
 	bool is_agile_input_event_flushing();
+
+	// Returns a cheap fingerprint of all action edge timestamps (pressed/released
+	// physics-frame counters). Used by Main::physics_iteration_step to assert that
+	// a dry-run tick does not consume any input action edges.
+	uint64_t get_action_edge_fingerprint() const;
+
 	void set_agile_input_event_flushing(bool p_enable);
 	void set_use_accumulated_input(bool p_enable);
 	bool is_using_accumulated_input();

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -277,9 +277,12 @@
 		<method name="physics_iteration">
 			<return type="bool" />
 			<param index="0" name="delta" type="float" />
+			<param index="1" name="dry_run" type="bool" default="false" />
 			<description>
-				Advances the physics simulation by exactly one tick of [param delta] seconds. Runs [method Node._physics_process], emits [signal SceneTree.physics_frame], updates navigation servers, flushes the message queue, and steps the [PhysicsServer2D] and [PhysicsServer3D] — the same sequence the automatic physics loop executes each tick. Also advances [method get_physics_frames] by [code]1[/code] and consumes input edges (see [method Input.is_action_just_pressed]).
-				Returns [code]true[/code] if the main loop requested termination during this tick (equivalent to [method SceneTree.quit] being called inside [method Node._physics_process]), matching the exit signal the automatic loop would have returned. Returns [code]false[/code] otherwise.
+				Advances the physics simulation by exactly one tick of [param delta] seconds.
+				When [param dry_run] is [code]false[/code] (the default), executes the full tick: runs [method Node._physics_process], emits [signal SceneTree.physics_frame], updates navigation servers, flushes the message queue, and steps the [PhysicsServer2D] and [PhysicsServer3D]. Also advances [method get_physics_frames] by [code]1[/code] and consumes input edges (see [method Input.is_action_just_pressed]).
+				When [param dry_run] is [code]true[/code], only the physics solver advances — [method Node._physics_process], navigation, message-queue flushes, and interpolation preparation are suppressed. [method get_physics_frames] is [b]not[/b] incremented and no input action edges are consumed. Use dry-run to predict future body positions (e.g. in a clone space) without disturbing the live world or the engine's frame counters.
+				Returns [code]true[/code] if the main loop requested termination during this tick (only possible when [param dry_run] is [code]false[/code]). Returns [code]false[/code] otherwise.
 				[b]Note:[/b] This method requires [member ProjectSettings.physics/common/manual_physics_stepping] to be [code]true[/code]. If that setting is [code]false[/code], an error is pushed, the call is a no-op, and [code]false[/code] is returned.
 				[b]Note:[/b] In Phase 1, enabling this setting does [i]not[/i] disable the automatic physics loop. Manual ticks are additive. Full loop-ownership transfer from script is out of scope until a later phase.
 				[b]Note:[/b] Mixing automatic stepping with manual stepping in the same frame may produce unintended input-edge consumption. Hardening of mixed auto+manual edge cases is deferred to a later phase.
@@ -290,6 +293,14 @@
 				    var N := 4
 				    for i in N:
 				        Engine.physics_iteration(delta / N)
+
+				# Dry-run prediction: step a clone space without side effects.
+				func predict_trajectory(clone_space: RID, steps: int, dt: float) -&gt; Array[Vector3]:
+				    var positions: Array[Vector3] = []
+				    for i in steps:
+				        Engine.physics_iteration(dt, true)  # dry_run=true
+				        positions.append(get_clone_body_position(clone_space))
+				    return positions
 				[/gdscript]
 				[csharp]
 				// Sub-stepping: advance physics at a finer rate than the automatic tick.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -1096,6 +1096,36 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="space_clone_state">
+			<return type="bool" />
+			<param index="0" name="src_space" type="RID" />
+			<param index="1" name="dst_space" type="RID" />
+			<description>
+				Copies the physics state of every body in [param src_space] into the corresponding body in [param dst_space], matched by registration order (ordinal index). Returns [code]true[/code] on success; [code]false[/code] if either RID is invalid, [param src_space] and [param dst_space] are the same space, or the body counts differ.
+				The clone is state-only: transform, linear velocity, angular velocity, and sleep/active state are copied. No bodies, areas, or joints are created or destroyed. The caller must pre-populate [param dst_space] with the same number of bodies in the same creation order as [param src_space].
+				Clone fidelity is [constant SPACE_FEATURE_PARTIAL] on all backends (query via [method space_get_feature] with [constant FEATURE_STATE_CLONE]).
+				The error mode is all-or-nothing: if body counts differ, a warning is printed and no body in [param dst_space] is modified.
+				[b]Note:[/b] Must be called from the main thread.
+				[codeblocks]
+				[gdscript]
+				var src = PhysicsServer2D.space_create()
+				PhysicsServer2D.space_set_active(src, true)
+				var dst = PhysicsServer2D.space_create()
+				PhysicsServer2D.space_set_active(dst, true)
+				# ... add matching bodies to both spaces in the same order ...
+				var ok: bool = PhysicsServer2D.space_clone_state(src, dst)
+				[/gdscript]
+				[csharp]
+				var src = PhysicsServer2D.SpaceCreate();
+				PhysicsServer2D.SpaceSetActive(src, true);
+				var dst = PhysicsServer2D.SpaceCreate();
+				PhysicsServer2D.SpaceSetActive(dst, true);
+				// ... add matching bodies to both spaces in the same order ...
+				bool ok = PhysicsServer2D.SpaceCloneState(src, dst);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="space_save_state">
 			<return type="PackedByteArray" />
 			<param index="0" name="space" type="RID" />
@@ -1370,6 +1400,9 @@
 		</constant>
 		<constant name="FEATURE_STATE_SNAPSHOT" value="0" enum="SpaceFeature">
 			Feature flag for state snapshot support. Pass this to [method space_get_feature] to query whether the active 2D backend can save and restore the complete simulation state via [method space_save_state] and [method space_restore_state].
+		</constant>
+		<constant name="FEATURE_STATE_CLONE" value="1" enum="SpaceFeature">
+			Feature flag for cross-space state clone support. Pass this to [method space_get_feature] to query the fidelity of [method space_clone_state] for the given space. All backends report [constant SPACE_FEATURE_PARTIAL]: clone copies the field set (transform, linear/angular velocity, sleep state) but does not preserve warm-start or contact-cache state.
 		</constant>
 		<constant name="SPACE_FEATURE_NONE" value="0" enum="SpaceFeatureSupport">
 			The active backend does not support this feature at all. [method space_save_state] will return an empty array and [method space_restore_state] will return [code]false[/code].

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1534,6 +1534,36 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="space_clone_state">
+			<return type="bool" />
+			<param index="0" name="src_space" type="RID" />
+			<param index="1" name="dst_space" type="RID" />
+			<description>
+				Copies the physics state of every body in [param src_space] into the corresponding body in [param dst_space], matched by registration order (ordinal index). Returns [code]true[/code] on success; [code]false[/code] if either RID is invalid, [param src_space] and [param dst_space] are the same space, or the body counts differ.
+				The clone is state-only: transform, linear velocity, angular velocity, and sleep/active state are copied. No bodies, areas, or joints are created or destroyed. The caller must pre-populate [param dst_space] with the same number of bodies in the same creation order as [param src_space].
+				Clone fidelity is [constant SPACE_FEATURE_PARTIAL] on all backends (query via [method space_get_feature] with [constant FEATURE_STATE_CLONE]). Warm-start and contact-cache state is not preserved across spaces, so the first step after a clone may diverge from the source trajectory before converging.
+				The error mode is all-or-nothing: if body counts differ, a warning is printed and no body in [param dst_space] is modified.
+				[b]Note:[/b] Must be called from the main thread.
+				[codeblocks]
+				[gdscript]
+				var src = PhysicsServer3D.space_create()
+				PhysicsServer3D.space_set_active(src, true)
+				var dst = PhysicsServer3D.space_create()
+				PhysicsServer3D.space_set_active(dst, true)
+				# ... add matching bodies to both spaces in the same order ...
+				var ok: bool = PhysicsServer3D.space_clone_state(src, dst)
+				[/gdscript]
+				[csharp]
+				var src = PhysicsServer3D.SpaceCreate();
+				PhysicsServer3D.SpaceSetActive(src, true);
+				var dst = PhysicsServer3D.SpaceCreate();
+				PhysicsServer3D.SpaceSetActive(dst, true);
+				// ... add matching bodies to both spaces in the same order ...
+				bool ok = PhysicsServer3D.SpaceCloneState(src, dst);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="space_save_state">
 			<return type="PackedByteArray" />
 			<param index="0" name="space" type="RID" />
@@ -2043,6 +2073,9 @@
 		</constant>
 		<constant name="FEATURE_STATE_SNAPSHOT" value="0" enum="SpaceFeature">
 			Feature flag for state snapshot support. Pass this to [method space_get_feature] to query whether the active backend can save and restore the complete simulation state via [method space_save_state] and [method space_restore_state].
+		</constant>
+		<constant name="FEATURE_STATE_CLONE" value="1" enum="SpaceFeature">
+			Feature flag for cross-space state clone support. Pass this to [method space_get_feature] to query the fidelity of [method space_clone_state] for the given space. All backends report [constant SPACE_FEATURE_PARTIAL]: clone copies the Phase-3 field set (transform, linear/angular velocity, sleep state) but does not preserve warm-start or contact-cache state, so the first step after a clone may diverge slightly from the source trajectory.
 		</constant>
 		<constant name="SPACE_FEATURE_NONE" value="0" enum="SpaceFeatureSupport">
 			The active backend does not support this feature at all. [method space_save_state] will return an empty array and [method space_restore_state] will return [code]false[/code].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4926,23 +4926,53 @@ static uint64_t navigation_process_ticks_last_frame = 0;
 // p_physics_step_ticks and p_navigation_process_ticks are per-frame accumulators
 // (largest-step tracking) passed in from the caller; they are updated in-place.
 // Returns true iff MainLoop::physics_process requested exit this tick.
-bool Main::physics_iteration_step(double p_physics_step, double p_time_scale) {
+//
+// p_dry_run: when true, the solver steps but all side effects that would corrupt the
+// live world (physics_frames advance, Input edge consumption, _physics_process dispatch,
+// navigation, message-queue flushes, interpolation prep) are suppressed. The two
+// prediction-critical invariants are enforced by DEV_ASSERT so a future refactor cannot
+// silently break them.
+bool Main::physics_iteration_step(double p_physics_step, double p_time_scale, bool p_dry_run) {
 	GodotProfileZone("Physics Step");
 	GodotProfileZoneGroupedFirst(_physics_zone, "setup");
-	if (Input::get_singleton()->is_agile_input_event_flushing()) {
-		Input::get_singleton()->flush_buffered_events();
+
+	// --- Dry-run assertion fingerprints (captured before any mutation) ---
+#ifdef DEV_ENABLED
+	const uint64_t frames_before = Engine::get_singleton()->get_physics_frames();
+	// Fingerprint for Input action-edge detection: sum of pressed/released physics-frame
+	// stamps across all tracked actions. A flush that consumes or creates an edge bumps
+	// one of these stamps, changing the sum.
+	const uint64_t input_edge_fingerprint_before =
+			(Input::get_singleton() != nullptr) ? Input::get_singleton()->get_action_edge_fingerprint() : 0;
+#endif // DEV_ENABLED
+
+	// Flush agile input events on the normal (non-dry-run) path only.
+	if (!p_dry_run) {
+		if (Input::get_singleton()->is_agile_input_event_flushing()) {
+			Input::get_singleton()->flush_buffered_events();
+		}
 	}
 
 	Engine::get_singleton()->_in_physics = true;
-	Engine::get_singleton()->_physics_frames++;
+
+	// Dry-run: do NOT advance _physics_frames (invariant A).
+	if (!p_dry_run) {
+		Engine::get_singleton()->_physics_frames++;
+	}
 
 	uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 
 	// Prepare the fixed timestep interpolated nodes BEFORE they are updated
 	// by the physics server, otherwise the current and previous transforms
 	// may be the same, and no interpolation takes place.
-	GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
-	OS::get_singleton()->get_main_loop()->iteration_prepare();
+	// Dry-run: skip — no node should observe a dry tick.
+	if (!p_dry_run) {
+		MainLoop *ml = OS::get_singleton()->get_main_loop();
+		if (ml != nullptr) {
+			GodotProfileZoneGrouped(_physics_zone, "main loop iteration prepare");
+			ml->iteration_prepare();
+		}
+	}
 
 #ifndef PHYSICS_3D_DISABLED
 	GodotProfileZoneGrouped(_physics_zone, "PhysicsServer3D::sync");
@@ -4956,39 +4986,45 @@ bool Main::physics_iteration_step(double p_physics_step, double p_time_scale) {
 	PhysicsServer2D::get_singleton()->flush_queries();
 #endif // PHYSICS_2D_DISABLED
 
-	GodotProfileZoneGrouped(_physics_zone, "physics_process");
-	if (OS::get_singleton()->get_main_loop()->physics_process(p_physics_step * p_time_scale)) {
+	// Dry-run: skip _physics_process dispatch (no node side effects).
+	if (!p_dry_run) {
+		MainLoop *ml = OS::get_singleton()->get_main_loop();
+		if (ml != nullptr) {
+			GodotProfileZoneGrouped(_physics_zone, "physics_process");
+			if (ml->physics_process(p_physics_step * p_time_scale)) {
 #ifndef PHYSICS_3D_DISABLED
-		PhysicsServer3D::get_singleton()->end_sync();
+				PhysicsServer3D::get_singleton()->end_sync();
 #endif // PHYSICS_3D_DISABLED
 #ifndef PHYSICS_2D_DISABLED
-		PhysicsServer2D::get_singleton()->end_sync();
+				PhysicsServer2D::get_singleton()->end_sync();
 #endif // PHYSICS_2D_DISABLED
 
-		Engine::get_singleton()->_in_physics = false;
-		return true;
-	}
+				Engine::get_singleton()->_in_physics = false;
+				return true;
+			}
+		}
 
 #if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-	uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
+		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
 
 #ifndef NAVIGATION_2D_DISABLED
-	GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
-	NavigationServer2D::get_singleton()->physics_process(p_physics_step * p_time_scale);
+		GodotProfileZoneGrouped(_profile_zone, "NavigationServer2D::physics_process");
+		NavigationServer2D::get_singleton()->physics_process(p_physics_step * p_time_scale);
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
-	GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
-	NavigationServer3D::get_singleton()->physics_process(p_physics_step * p_time_scale);
+		GodotProfileZoneGrouped(_profile_zone, "NavigationServer3D::physics_process");
+		NavigationServer3D::get_singleton()->physics_process(p_physics_step * p_time_scale);
 #endif // NAVIGATION_3D_DISABLED
 
-	{
-		const uint64_t nav_elapsed = OS::get_singleton()->get_ticks_usec() - navigation_begin;
-		navigation_process_ticks_last_frame = MAX(navigation_process_ticks_last_frame, nav_elapsed); // keep the largest one for reference
-		navigation_process_max = MAX(nav_elapsed, navigation_process_max);
-	}
+		{
+			const uint64_t nav_elapsed = OS::get_singleton()->get_ticks_usec() - navigation_begin;
+			navigation_process_ticks_last_frame = MAX(navigation_process_ticks_last_frame, nav_elapsed); // keep the largest one for reference
+			navigation_process_max = MAX(nav_elapsed, navigation_process_max);
+		}
 
-	message_queue->flush();
+		message_queue->flush();
 #endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+	} // end !p_dry_run (skip _physics_process and navigation)
 
 #ifndef PHYSICS_3D_DISABLED
 	GodotProfileZoneGrouped(_profile_zone, "3D physics");
@@ -5002,10 +5038,16 @@ bool Main::physics_iteration_step(double p_physics_step, double p_time_scale) {
 	PhysicsServer2D::get_singleton()->step(p_physics_step * p_time_scale);
 #endif // PHYSICS_2D_DISABLED
 
-	message_queue->flush();
+	// Dry-run: skip message-queue flush and iteration_end.
+	if (!p_dry_run) {
+		message_queue->flush();
 
-	GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
-	OS::get_singleton()->get_main_loop()->iteration_end();
+		MainLoop *ml = OS::get_singleton()->get_main_loop();
+		if (ml != nullptr) {
+			GodotProfileZoneGrouped(_profile_zone, "main loop iteration end");
+			ml->iteration_end();
+		}
+	}
 
 	{
 		const uint64_t phys_elapsed = OS::get_singleton()->get_ticks_usec() - physics_begin;
@@ -5014,6 +5056,19 @@ bool Main::physics_iteration_step(double p_physics_step, double p_time_scale) {
 	}
 
 	Engine::get_singleton()->_in_physics = false;
+
+	// --- Dry-run invariant assertions ---
+#ifdef DEV_ENABLED
+	if (p_dry_run) {
+		// Invariant A: physics_frames must not have advanced.
+		DEV_ASSERT(Engine::get_singleton()->get_physics_frames() == frames_before);
+		// Invariant B: Input action edges must not have been consumed.
+		const uint64_t input_edge_fingerprint_after =
+				(Input::get_singleton() != nullptr) ? Input::get_singleton()->get_action_edge_fingerprint() : 0;
+		DEV_ASSERT(input_edge_fingerprint_after == input_edge_fingerprint_before);
+	}
+#endif // DEV_ENABLED
+
 	return false;
 }
 
@@ -5279,6 +5334,11 @@ void Main::cleanup(bool p_force) {
 	message_queue->flush();
 
 	OS::get_singleton()->delete_main_loop();
+
+	// Clear the manual-physics callback so a stale function pointer cannot be
+	// dereferenced after the main loop is gone. Must be after delete_main_loop()
+	// and before finalize_physics() (forward-note from PR #10 security audit).
+	Engine::get_singleton()->set_manual_physics_iteration_callback(nullptr);
 
 	OS::get_singleton()->_cmdline.clear();
 	OS::get_singleton()->_user_args.clear();

--- a/main/main.h
+++ b/main/main.h
@@ -81,7 +81,7 @@ public:
 	// physics for-loop. Returns true iff MainLoop::physics_process requested exit.
 	// Registered as a callback on ::Engine at startup so core_bind can invoke it
 	// without a core→main reverse dependency.
-	static bool physics_iteration_step(double p_physics_step, double p_time_scale);
+	static bool physics_iteration_step(double p_physics_step, double p_time_scale, bool p_dry_run = false);
 
 	static bool iteration();
 	static void force_redraw();

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1620,8 +1620,66 @@ void GodotPhysicsServer2D::space_reset(RID p_space) {
 	}
 }
 
+bool GodotPhysicsServer2D::space_clone_state(RID p_src_space, RID p_dst_space) {
+	GodotSpace2D *src = space_owner.get_or_null(p_src_space);
+	ERR_FAIL_NULL_V_MSG(src, false, "space_clone_state: invalid src_space RID.");
+	GodotSpace2D *dst = space_owner.get_or_null(p_dst_space);
+	ERR_FAIL_NULL_V_MSG(dst, false, "space_clone_state: invalid dst_space RID.");
+	ERR_FAIL_COND_V_MSG(src == dst, false, "space_clone_state: src_space and dst_space must differ.");
+
+	// Collect bodies in stable insertion order (NOT get_objects() — HashSet order is unstable).
+	LocalVector<GodotBody2D *> src_bodies;
+	LocalVector<GodotBody2D *> dst_bodies;
+
+	for (GodotCollisionObject2D *obj : src->get_objects_ordered()) {
+		if (obj->get_type() == GodotCollisionObject2D::TYPE_BODY) {
+			src_bodies.push_back(static_cast<GodotBody2D *>(obj));
+		}
+	}
+	for (GodotCollisionObject2D *obj : dst->get_objects_ordered()) {
+		if (obj->get_type() == GodotCollisionObject2D::TYPE_BODY) {
+			dst_bodies.push_back(static_cast<GodotBody2D *>(obj));
+		}
+	}
+
+	// All-or-nothing: body count must match.
+	if (src_bodies.size() != dst_bodies.size()) {
+		WARN_PRINT("space_clone_state: body count mismatch between src and dst spaces — no state was written.");
+		return false;
+	}
+
+	// Stage all source state before writing any destination body (no partial write).
+	struct BodyState2D {
+		Transform2D transform;
+		Vector2 linear_velocity;
+		real_t angular_velocity;
+		bool active;
+	};
+	LocalVector<BodyState2D> staged;
+	staged.resize(src_bodies.size());
+	for (uint32_t i = 0; i < src_bodies.size(); i++) {
+		staged[i].transform = src_bodies[i]->get_transform();
+		staged[i].linear_velocity = src_bodies[i]->get_linear_velocity();
+		staged[i].angular_velocity = src_bodies[i]->get_angular_velocity();
+		staged[i].active = src_bodies[i]->is_active();
+	}
+
+	// Apply staged state to dst bodies pairwise (ordinal i → ordinal i).
+	for (uint32_t i = 0; i < dst_bodies.size(); i++) {
+		dst_bodies[i]->set_state(BODY_STATE_TRANSFORM, staged[i].transform);
+		dst_bodies[i]->set_linear_velocity(staged[i].linear_velocity);
+		dst_bodies[i]->set_angular_velocity(staged[i].angular_velocity);
+		dst_bodies[i]->set_active(staged[i].active);
+	}
+
+	return true;
+}
+
 int GodotPhysicsServer2D::space_get_feature(RID p_space, SpaceFeature p_feature) const {
 	if (p_feature == FEATURE_STATE_SNAPSHOT) {
+		return SPACE_FEATURE_PARTIAL;
+	}
+	if (p_feature == FEATURE_STATE_CLONE) {
 		return SPACE_FEATURE_PARTIAL;
 	}
 	return SPACE_FEATURE_NONE;

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -298,6 +298,7 @@ public:
 	virtual void space_flush_queries(RID p_space) override;
 	virtual PackedByteArray space_save_state(RID p_space) override;
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override;
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override;
 	virtual void space_reset(RID p_space) override;
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const override;
 	virtual void finish() override;

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -1078,11 +1078,19 @@ GodotBroadPhase2D *GodotSpace2D::get_broadphase() {
 void GodotSpace2D::add_object(GodotCollisionObject2D *p_object) {
 	ERR_FAIL_COND(objects.has(p_object));
 	objects.insert(p_object);
+	objects_ordered.push_back(p_object);
 }
 
 void GodotSpace2D::remove_object(GodotCollisionObject2D *p_object) {
 	ERR_FAIL_COND(!objects.has(p_object));
 	objects.erase(p_object);
+	// Maintain insertion-order list: find and erase by value.
+	for (uint32_t i = 0; i < objects_ordered.size(); i++) {
+		if (objects_ordered[i] == p_object) {
+			objects_ordered.remove_at(i);
+			break;
+		}
+	}
 }
 
 const HashSet<GodotCollisionObject2D *> &GodotSpace2D::get_objects() const {

--- a/modules/godot_physics_2d/godot_space_2d.h
+++ b/modules/godot_physics_2d/godot_space_2d.h
@@ -88,6 +88,10 @@ private:
 	static void _broadphase_unpair(GodotCollisionObject2D *A, int p_subindex_A, GodotCollisionObject2D *B, int p_subindex_B, void *p_data, void *p_self);
 
 	HashSet<GodotCollisionObject2D *> objects;
+	// Insertion-order-stable list of registered objects, maintained in parallel
+	// with the HashSet. Used by space_clone_state to produce a deterministic
+	// ordinal index for each object.
+	LocalVector<GodotCollisionObject2D *> objects_ordered;
 
 	GodotArea2D *area = nullptr;
 
@@ -152,6 +156,8 @@ public:
 	void add_object(GodotCollisionObject2D *p_object);
 	void remove_object(GodotCollisionObject2D *p_object);
 	const HashSet<GodotCollisionObject2D *> &get_objects() const;
+	// Returns objects in stable insertion order (for space_clone_state ordinal pairing).
+	const LocalVector<GodotCollisionObject2D *> &get_objects_ordered() const { return objects_ordered; }
 
 	_FORCE_INLINE_ int get_solver_iterations() const { return solver_iterations; }
 	_FORCE_INLINE_ real_t get_contact_recycle_radius() const { return contact_recycle_radius; }

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -2052,8 +2052,66 @@ void GodotPhysicsServer3D::space_reset(RID p_space) {
 	// Joint RIDs remain valid per the spec (not freed).
 }
 
+bool GodotPhysicsServer3D::space_clone_state(RID p_src_space, RID p_dst_space) {
+	GodotSpace3D *src = space_owner.get_or_null(p_src_space);
+	ERR_FAIL_NULL_V_MSG(src, false, "space_clone_state: invalid src_space RID.");
+	GodotSpace3D *dst = space_owner.get_or_null(p_dst_space);
+	ERR_FAIL_NULL_V_MSG(dst, false, "space_clone_state: invalid dst_space RID.");
+	ERR_FAIL_COND_V_MSG(src == dst, false, "space_clone_state: src_space and dst_space must differ.");
+
+	// Collect bodies in stable insertion order (NOT get_objects() — HashSet order is unstable).
+	LocalVector<GodotBody3D *> src_bodies;
+	LocalVector<GodotBody3D *> dst_bodies;
+
+	for (GodotCollisionObject3D *obj : src->get_objects_ordered()) {
+		if (obj->get_type() == GodotCollisionObject3D::TYPE_BODY) {
+			src_bodies.push_back(static_cast<GodotBody3D *>(obj));
+		}
+	}
+	for (GodotCollisionObject3D *obj : dst->get_objects_ordered()) {
+		if (obj->get_type() == GodotCollisionObject3D::TYPE_BODY) {
+			dst_bodies.push_back(static_cast<GodotBody3D *>(obj));
+		}
+	}
+
+	// All-or-nothing: body count must match.
+	if (src_bodies.size() != dst_bodies.size()) {
+		WARN_PRINT("space_clone_state: body count mismatch between src and dst spaces — no state was written.");
+		return false;
+	}
+
+	// Stage all source state before writing any destination body (no partial write).
+	struct BodyState3D {
+		Transform3D transform;
+		Vector3 linear_velocity;
+		Vector3 angular_velocity;
+		bool active;
+	};
+	LocalVector<BodyState3D> staged;
+	staged.resize(src_bodies.size());
+	for (uint32_t i = 0; i < src_bodies.size(); i++) {
+		staged[i].transform = src_bodies[i]->get_transform();
+		staged[i].linear_velocity = src_bodies[i]->get_linear_velocity();
+		staged[i].angular_velocity = src_bodies[i]->get_angular_velocity();
+		staged[i].active = src_bodies[i]->is_active();
+	}
+
+	// Apply staged state to dst bodies pairwise (ordinal i → ordinal i).
+	for (uint32_t i = 0; i < dst_bodies.size(); i++) {
+		dst_bodies[i]->set_state(BODY_STATE_TRANSFORM, staged[i].transform);
+		dst_bodies[i]->set_linear_velocity(staged[i].linear_velocity);
+		dst_bodies[i]->set_angular_velocity(staged[i].angular_velocity);
+		dst_bodies[i]->set_active(staged[i].active);
+	}
+
+	return true;
+}
+
 int GodotPhysicsServer3D::space_get_feature(RID p_space, SpaceFeature p_feature) const {
 	if (p_feature == FEATURE_STATE_SNAPSHOT) {
+		return SPACE_FEATURE_PARTIAL;
+	}
+	if (p_feature == FEATURE_STATE_CLONE) {
 		return SPACE_FEATURE_PARTIAL;
 	}
 	return SPACE_FEATURE_NONE;

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -385,6 +385,7 @@ public:
 	virtual void space_flush_queries(RID p_space) override;
 	virtual PackedByteArray space_save_state(RID p_space) override;
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override;
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override;
 	virtual void space_reset(RID p_space) override;
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const override;
 

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -1112,11 +1112,19 @@ GodotBroadPhase3D *GodotSpace3D::get_broadphase() {
 void GodotSpace3D::add_object(GodotCollisionObject3D *p_object) {
 	ERR_FAIL_COND(objects.has(p_object));
 	objects.insert(p_object);
+	objects_ordered.push_back(p_object);
 }
 
 void GodotSpace3D::remove_object(GodotCollisionObject3D *p_object) {
 	ERR_FAIL_COND(!objects.has(p_object));
 	objects.erase(p_object);
+	// Maintain insertion-order list: find and erase by value.
+	for (uint32_t i = 0; i < objects_ordered.size(); i++) {
+		if (objects_ordered[i] == p_object) {
+			objects_ordered.remove_at(i);
+			break;
+		}
+	}
 }
 
 const HashSet<GodotCollisionObject3D *> &GodotSpace3D::get_objects() const {

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -85,6 +85,10 @@ private:
 	static void _broadphase_unpair(GodotCollisionObject3D *A, int p_subindex_A, GodotCollisionObject3D *B, int p_subindex_B, void *p_data, void *p_self);
 
 	HashSet<GodotCollisionObject3D *> objects;
+	// Insertion-order-stable list of registered objects, maintained in parallel
+	// with the HashSet. Used by space_clone_state to produce a deterministic
+	// ordinal index for each object. Never iterate objects directly for clone ops.
+	LocalVector<GodotCollisionObject3D *> objects_ordered;
 
 	GodotArea3D *area = nullptr;
 
@@ -154,6 +158,8 @@ public:
 	void add_object(GodotCollisionObject3D *p_object);
 	void remove_object(GodotCollisionObject3D *p_object);
 	const HashSet<GodotCollisionObject3D *> &get_objects() const;
+	// Returns objects in stable insertion order (for space_clone_state ordinal pairing).
+	const LocalVector<GodotCollisionObject3D *> &get_objects_ordered() const { return objects_ordered; }
 
 	_FORCE_INLINE_ int get_solver_iterations() const { return solver_iterations; }
 	_FORCE_INLINE_ real_t get_contact_recycle_radius() const { return contact_recycle_radius; }

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1867,9 +1867,85 @@ void JoltPhysicsServer3D::space_reset(RID p_space) {
 	// from the physics system. Joint RIDs remain valid (not freed) per the spec.
 }
 
+bool JoltPhysicsServer3D::space_clone_state(RID p_src_space, RID p_dst_space) {
+	JoltSpace3D *src = space_owner.get_or_null(p_src_space);
+	ERR_FAIL_NULL_V_MSG(src, false, "space_clone_state: invalid src_space RID.");
+	JoltSpace3D *dst = space_owner.get_or_null(p_dst_space);
+	ERR_FAIL_NULL_V_MSG(dst, false, "space_clone_state: invalid dst_space RID.");
+	ERR_FAIL_COND_V_MSG(src == dst, false, "space_clone_state: src_space and dst_space must differ.");
+
+	// Collect bodies in both spaces, sorted by RID id (ascending).
+	// Jolt has no insertion-order list; sorting by RID id is a stable ordinal key
+	// provided the caller built dst by replaying src's creation order.
+	// Note: Jolt's same-space StateRecorder blob is BodyID-keyed and cannot cross
+	// independent PhysicsSystems, so this clone carries the Phase-3 field set only
+	// (PARTIAL fidelity — no warm-start/contact state).
+	LocalVector<JoltBody3D *> src_bodies;
+	LocalVector<JoltBody3D *> dst_bodies;
+
+	{
+		LocalVector<RID> rids = body_owner.get_owned_list();
+		for (const RID &rid : rids) {
+			JoltBody3D *body = body_owner.get_or_null(rid);
+			if (body == nullptr) {
+				continue;
+			}
+			if (body->get_space() == src) {
+				src_bodies.push_back(body);
+			} else if (body->get_space() == dst) {
+				dst_bodies.push_back(body);
+			}
+		}
+	}
+
+	// Sort both lists by RID id ascending (deterministic ordinal key).
+	struct ByRid {
+		bool operator()(const JoltBody3D *a, const JoltBody3D *b) const {
+			return a->get_rid().get_id() < b->get_rid().get_id();
+		}
+	};
+	src_bodies.sort_custom<ByRid>();
+	dst_bodies.sort_custom<ByRid>();
+
+	// All-or-nothing: body count must match.
+	if (src_bodies.size() != dst_bodies.size()) {
+		WARN_PRINT("space_clone_state: body count mismatch between src and dst spaces — no state was written.");
+		return false;
+	}
+
+	// Stage all source state before writing any destination body (no partial write).
+	struct BodyState {
+		Transform3D transform;
+		Vector3 linear_velocity;
+		Vector3 angular_velocity;
+		bool sleeping;
+	};
+	LocalVector<BodyState> staged;
+	staged.resize(src_bodies.size());
+	for (uint32_t i = 0; i < src_bodies.size(); i++) {
+		staged[i].transform = src_bodies[i]->get_transform_unscaled();
+		staged[i].linear_velocity = src_bodies[i]->get_linear_velocity();
+		staged[i].angular_velocity = src_bodies[i]->get_angular_velocity();
+		staged[i].sleeping = src_bodies[i]->is_sleeping();
+	}
+
+	// Apply staged state to dst bodies pairwise (ordinal i → ordinal i).
+	for (uint32_t i = 0; i < dst_bodies.size(); i++) {
+		dst_bodies[i]->set_transform(staged[i].transform);
+		dst_bodies[i]->set_linear_velocity(staged[i].linear_velocity);
+		dst_bodies[i]->set_angular_velocity(staged[i].angular_velocity);
+		dst_bodies[i]->set_is_sleeping(staged[i].sleeping);
+	}
+
+	return true;
+}
+
 int JoltPhysicsServer3D::space_get_feature(RID p_space, SpaceFeature p_feature) const {
 	if (p_feature == FEATURE_STATE_SNAPSHOT) {
 		return SPACE_FEATURE_FULL;
+	}
+	if (p_feature == FEATURE_STATE_CLONE) {
+		return SPACE_FEATURE_PARTIAL;
 	}
 	return SPACE_FEATURE_NONE;
 }

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -432,6 +432,7 @@ public:
 	virtual void space_flush_queries(RID p_space) override;
 	virtual PackedByteArray space_save_state(RID p_space) override;
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override;
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override;
 	virtual void space_reset(RID p_space) override;
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const override;
 

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -653,6 +653,7 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_step_safe", "space", "delta"), &PhysicsServer2D::space_step_safe);
 	ClassDB::bind_method(D_METHOD("space_save_state", "space"), &PhysicsServer2D::space_save_state);
 	ClassDB::bind_method(D_METHOD("space_restore_state", "space", "state"), &PhysicsServer2D::space_restore_state);
+	ClassDB::bind_method(D_METHOD("space_clone_state", "src_space", "dst_space"), &PhysicsServer2D::space_clone_state);
 	ClassDB::bind_method(D_METHOD("space_reset", "space"), &PhysicsServer2D::space_reset);
 	ClassDB::bind_method(D_METHOD("space_get_feature", "space", "feature"), &PhysicsServer2D::space_get_feature);
 
@@ -908,6 +909,7 @@ void PhysicsServer2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(INFO_ISLAND_COUNT);
 
 	BIND_ENUM_CONSTANT(FEATURE_STATE_SNAPSHOT);
+	BIND_ENUM_CONSTANT(FEATURE_STATE_CLONE);
 
 	BIND_ENUM_CONSTANT(SPACE_FEATURE_NONE);
 	BIND_ENUM_CONSTANT(SPACE_FEATURE_PARTIAL);

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -621,6 +621,7 @@ public:
 
 	enum SpaceFeature {
 		FEATURE_STATE_SNAPSHOT = 0,
+		FEATURE_STATE_CLONE = 1,
 	};
 
 	enum SpaceFeatureSupport {
@@ -631,6 +632,7 @@ public:
 
 	virtual PackedByteArray space_save_state(RID p_space) = 0;
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) = 0;
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) = 0;
 	virtual void space_reset(RID p_space) = 0;
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const { return SPACE_FEATURE_NONE; }
 

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -347,6 +347,7 @@ public:
 	virtual void space_flush_queries(RID p_space) override {}
 	virtual PackedByteArray space_save_state(RID p_space) override { return PackedByteArray(); }
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override { return false; }
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override { return false; }
 	virtual void space_reset(RID p_space) override {}
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const override { return SPACE_FEATURE_NONE; }
 

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -352,6 +352,7 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_space_flush_queries, "space");
 	GDVIRTUAL_BIND(_space_save_state, "space");
 	GDVIRTUAL_BIND(_space_restore_state, "space", "state");
+	GDVIRTUAL_BIND(_space_clone_state, "src_space", "dst_space");
 	GDVIRTUAL_BIND(_space_reset, "space");
 	GDVIRTUAL_BIND(_space_get_feature, "space", "feature");
 

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -458,6 +458,7 @@ public:
 	EXBIND1(space_flush_queries, RID)
 	EXBIND1R(PackedByteArray, space_save_state, RID)
 	EXBIND2R(bool, space_restore_state, RID, const PackedByteArray &)
+	EXBIND2R(bool, space_clone_state, RID, RID)
 	EXBIND1(space_reset, RID)
 	EXBIND2RC(int, space_get_feature, RID, SpaceFeature)
 

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -149,6 +149,16 @@ public:
 		end_sync();
 		return ok;
 	}
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override {
+		// Single critical section: hold the physics lock across the full
+		// src-read and dst-write so no state can advance between them.
+		ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), false,
+				"space_clone_state must be called from the main thread.");
+		sync();
+		bool ok = physics_server_2d->space_clone_state(p_src_space, p_dst_space);
+		end_sync();
+		return ok;
+	}
 	virtual void space_reset(RID p_space) override {
 		ERR_FAIL_COND_MSG(!Thread::is_main_thread(),
 				"space_reset must be called from the main thread.");

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -728,6 +728,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_step_safe", "space", "delta"), &PhysicsServer3D::space_step_safe);
 	ClassDB::bind_method(D_METHOD("space_save_state", "space"), &PhysicsServer3D::space_save_state);
 	ClassDB::bind_method(D_METHOD("space_restore_state", "space", "state"), &PhysicsServer3D::space_restore_state);
+	ClassDB::bind_method(D_METHOD("space_clone_state", "src_space", "dst_space"), &PhysicsServer3D::space_clone_state);
 	ClassDB::bind_method(D_METHOD("space_reset", "space"), &PhysicsServer3D::space_reset);
 	ClassDB::bind_method(D_METHOD("space_get_feature", "space", "feature"), &PhysicsServer3D::space_get_feature);
 
@@ -1141,6 +1142,7 @@ void PhysicsServer3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(BODY_AXIS_ANGULAR_Z);
 
 	BIND_ENUM_CONSTANT(FEATURE_STATE_SNAPSHOT);
+	BIND_ENUM_CONSTANT(FEATURE_STATE_CLONE);
 
 	BIND_ENUM_CONSTANT(SPACE_FEATURE_NONE);
 	BIND_ENUM_CONSTANT(SPACE_FEATURE_PARTIAL);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -824,6 +824,7 @@ public:
 
 	enum SpaceFeature {
 		FEATURE_STATE_SNAPSHOT = 0,
+		FEATURE_STATE_CLONE = 1,
 	};
 
 	enum SpaceFeatureSupport {
@@ -834,6 +835,7 @@ public:
 
 	virtual PackedByteArray space_save_state(RID p_space) = 0;
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) = 0;
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) = 0;
 	virtual void space_reset(RID p_space) = 0;
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const { return SPACE_FEATURE_NONE; }
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -441,6 +441,7 @@ public:
 	virtual void space_flush_queries(RID p_space) override {}
 	virtual PackedByteArray space_save_state(RID p_space) override { return PackedByteArray(); }
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override { return false; }
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override { return false; }
 	virtual void space_reset(RID p_space) override {}
 	virtual int space_get_feature(RID p_space, SpaceFeature p_feature) const override { return SPACE_FEATURE_NONE; }
 	virtual void finish() override {

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -440,6 +440,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_space_flush_queries, "space");
 	GDVIRTUAL_BIND(_space_save_state, "space");
 	GDVIRTUAL_BIND(_space_restore_state, "space", "state");
+	GDVIRTUAL_BIND(_space_clone_state, "src_space", "dst_space");
 	GDVIRTUAL_BIND(_space_reset, "space");
 	GDVIRTUAL_BIND(_space_get_feature, "space", "feature");
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -550,6 +550,7 @@ public:
 	EXBIND1(space_flush_queries, RID)
 	EXBIND1R(PackedByteArray, space_save_state, RID)
 	EXBIND2R(bool, space_restore_state, RID, const PackedByteArray &)
+	EXBIND2R(bool, space_clone_state, RID, RID)
 	EXBIND1(space_reset, RID)
 	EXBIND2RC(int, space_get_feature, RID, SpaceFeature)
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -155,6 +155,16 @@ public:
 		end_sync();
 		return ok;
 	}
+	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override {
+		// Single critical section: hold the physics lock across the full
+		// src-read and dst-write so no state can advance between them.
+		ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), false,
+				"space_clone_state must be called from the main thread.");
+		sync();
+		bool ok = physics_server_3d->space_clone_state(p_src_space, p_dst_space);
+		end_sync();
+		return ok;
+	}
 	virtual void space_reset(RID p_space) override {
 		ERR_FAIL_COND_MSG(!Thread::is_main_thread(),
 				"space_reset must be called from the main thread.");

--- a/tests/servers/test_physics_server_2d_space_clone.cpp
+++ b/tests/servers/test_physics_server_2d_space_clone.cpp
@@ -1,0 +1,336 @@
+/**************************************************************************/
+/*  test_physics_server_2d_space_clone.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+// Phase 4 — 2D parity doctest for space_clone_state.
+//
+// Mirrors test_physics_server_3d_space_clone.cpp: every test case has a 2D
+// counterpart so the AC coverage table is symmetric across dimensions.
+//
+// Covered ACs (ticket #6):
+//   AC1  — ordinal-copy: matching body counts, state copied by registration order.
+//   AC3  — count-mismatch: returns false, no partial write (all-or-nothing).
+//   AC3  — src == dst guard: returns false.
+//   AC3  — invalid-RID guards: both src-invalid and dst-invalid return false.
+//   AC4  — FEATURE_STATE_CLONE: dummy returns NONE; real 2D backend returns PARTIAL.
+//   AC2  — two-budget trajectory: clone + N steps tracks src within tolerances.
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_physics_server_2d_space_clone)
+
+#ifndef PHYSICS_2D_DISABLED
+
+#include "servers/physics_2d/physics_server_2d.h"
+#include "servers/physics_2d/physics_server_2d_dummy.h"
+
+namespace TestPhysicsServer2DSpaceClone {
+
+static bool is_dummy_server() {
+	return Object::cast_to<PhysicsServer2DDummy>(PhysicsServer2D::get_singleton()) != nullptr;
+}
+
+static Vector2 get_body_origin(PhysicsServer2D *ps, RID body) {
+	Variant v = ps->body_get_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM);
+	return ((Transform2D)v).get_origin();
+}
+
+// Helper: create a circle body in a 2D space at the given position.
+// r_shape receives the created shape RID so the caller can free it.
+static RID make_body(PhysicsServer2D *ps, RID space, const Vector2 &p_pos, RID &r_shape) {
+	r_shape = ps->circle_shape_create();
+	ps->shape_set_data(r_shape, 0.5f);
+	RID body = ps->body_create();
+	ps->body_set_space(body, space);
+	ps->body_add_shape(body, r_shape);
+	ps->body_set_mode(body, PhysicsServer2D::BODY_MODE_RIGID);
+	ps->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM,
+			Transform2D(0.0f, p_pos));
+	return body;
+}
+
+TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
+	// -----------------------------------------------------------------------
+	// AC4 — FEATURE_STATE_CLONE enum value and space_get_feature reports.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] FEATURE_STATE_CLONE: dummy returns NONE") {
+		if (!is_dummy_server()) {
+			WARN("Test targets dummy server but a real backend is loaded — skipping.");
+			return;
+		}
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		CHECK_EQ(ps->space_get_feature(space, PhysicsServer2D::FEATURE_STATE_CLONE),
+				(int)PhysicsServer2D::SPACE_FEATURE_NONE);
+		ps->free_rid(space);
+	}
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] FEATURE_STATE_CLONE: real backend returns PARTIAL") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		int feat = ps->space_get_feature(space, PhysicsServer2D::FEATURE_STATE_CLONE);
+		CHECK_MESSAGE(feat == (int)PhysicsServer2D::SPACE_FEATURE_PARTIAL,
+				"Real 2D backend must report PARTIAL for FEATURE_STATE_CLONE (field-set copy only, no warm-start).");
+		ps->free_rid(space);
+	}
+
+	// -----------------------------------------------------------------------
+	// AC1 — space_clone_state: round-trip ordinal copy.
+	// Stepping dst after clone must NOT perturb src (isolation).
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: copies body state by ordinal") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID src_space = ps->space_create();
+		ps->space_set_active(src_space, true);
+		RID dst_space = ps->space_create();
+		ps->space_set_active(dst_space, true);
+
+		// Create matching bodies in src and dst (same registration order).
+		RID src_shape, dst_shape;
+		const Vector2 src_pos(1.0f, 10.0f);
+		RID src_body = make_body(ps, src_space, src_pos, src_shape);
+		const Vector2 dst_pos(0.0f, 0.0f);
+		RID dst_body = make_body(ps, dst_space, dst_pos, dst_shape);
+
+		// Set a known linear velocity on src so we can verify it was cloned.
+		const Vector2 src_vel(3.0f, 0.0f);
+		ps->body_set_state(src_body, PhysicsServer2D::BODY_STATE_LINEAR_VELOCITY, src_vel);
+
+		bool ok = ps->space_clone_state(src_space, dst_space);
+		CHECK_MESSAGE(ok, "space_clone_state must return true for matching body counts.");
+
+		// dst body must now have src body's position.
+		Vector2 dst_origin = get_body_origin(ps, dst_body);
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.x, src_pos.x, (real_t)0.01),
+				"Clone: dst body X must match src body X.");
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.y, src_pos.y, (real_t)0.01),
+				"Clone: dst body Y must match src body Y.");
+
+		// dst body must now have src body's linear velocity.
+		Variant lv_v = ps->body_get_state(dst_body, PhysicsServer2D::BODY_STATE_LINEAR_VELOCITY);
+		Vector2 dst_vel = (Vector2)lv_v;
+		CHECK_MESSAGE(Math::is_equal_approx(dst_vel.x, src_vel.x, (real_t)0.01),
+				"Clone: dst body linear velocity X must match src.");
+
+		// Isolation: step dst only — src must remain unchanged.
+		Vector2 src_origin_before = get_body_origin(ps, src_body);
+		ps->space_step_safe(dst_space, 1.0f / 60.0f);
+		Vector2 src_origin_after = get_body_origin(ps, src_body);
+		CHECK_MESSAGE(Math::is_equal_approx(src_origin_after.x, src_origin_before.x, (real_t)0.01),
+				"Isolation: stepping dst must not change src body X.");
+		CHECK_MESSAGE(Math::is_equal_approx(src_origin_after.y, src_origin_before.y, (real_t)0.01),
+				"Isolation: stepping dst must not change src body Y.");
+
+		ps->free_rid(src_body);
+		ps->free_rid(dst_body);
+		ps->free_rid(src_shape);
+		ps->free_rid(dst_shape);
+		ps->free_rid(src_space);
+		ps->free_rid(dst_space);
+	}
+
+	// -----------------------------------------------------------------------
+	// AC3 — space_clone_state: count mismatch returns false, no partial write.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: count mismatch returns false, no partial write") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID src_space = ps->space_create();
+		ps->space_set_active(src_space, true);
+		RID dst_space = ps->space_create();
+		ps->space_set_active(dst_space, true);
+
+		// src has one body, dst has two — mismatch.
+		RID src_shape;
+		const Vector2 src_pos(7.0f, 7.0f);
+		RID src_body = make_body(ps, src_space, src_pos, src_shape);
+
+		const Vector2 dst_pos_before(0.0f, 0.0f);
+		RID dst_shape_a, dst_shape_b;
+		RID dst_body_a = make_body(ps, dst_space, dst_pos_before, dst_shape_a);
+		RID dst_body_b = make_body(ps, dst_space, Vector2(1.0f, 1.0f), dst_shape_b);
+
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(src_space, dst_space);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state must return false on body count mismatch.");
+
+		// dst_body_a must still be at its original position (no partial write).
+		Vector2 dst_origin = get_body_origin(ps, dst_body_a);
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.x, dst_pos_before.x, (real_t)0.01),
+				"On count mismatch dst body must be unchanged (no partial write) — X.");
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.y, dst_pos_before.y, (real_t)0.01),
+				"On count mismatch dst body must be unchanged (no partial write) — Y.");
+
+		ps->free_rid(src_body);
+		ps->free_rid(dst_body_a);
+		ps->free_rid(dst_body_b);
+		ps->free_rid(src_shape);
+		ps->free_rid(dst_shape_a);
+		ps->free_rid(dst_shape_b);
+		ps->free_rid(src_space);
+		ps->free_rid(dst_space);
+	}
+
+	// -----------------------------------------------------------------------
+	// AC3 — space_clone_state: src == dst returns false.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: src == dst returns false") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(space, space);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state(space, space) must return false.");
+		ps->free_rid(space);
+	}
+
+	// -----------------------------------------------------------------------
+	// AC3 — space_clone_state: invalid-RID guards.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: invalid src RID returns false") {
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(RID(), space);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state with invalid src must return false.");
+		ps->free_rid(space);
+	}
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: invalid dst RID returns false") {
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(space, RID());
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state with invalid dst must return false.");
+		ps->free_rid(space);
+	}
+
+	// -----------------------------------------------------------------------
+	// AC2 — Two-budget trajectory tolerance (2D parity).
+	//
+	// After clone + N steps, dst trajectory matches a continuous src run within:
+	//   first-step budget  : < 0.5 px (cold-contact transient)
+	//   steady-state budget: < 1e-3 px per step (propose-and-measure)
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: cloned space trajectory within two-budget tolerance") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID src_space = ps->space_create();
+		ps->space_set_active(src_space, true);
+		RID dst_space = ps->space_create();
+		ps->space_set_active(dst_space, true);
+
+		const real_t dt = (real_t)(1.0 / 60.0);
+		// Start high so the body is in free-fall for N steps without hitting anything.
+		const Vector2 start(0.0f, -200.0f);
+
+		RID src_shape, dst_shape;
+		RID src_body = make_body(ps, src_space, start, src_shape);
+		RID dst_body = make_body(ps, dst_space, start, dst_shape);
+
+		// Step src once to settle from cold start, then clone to dst.
+		ps->space_step_safe(src_space, dt);
+
+		bool ok = ps->space_clone_state(src_space, dst_space);
+		REQUIRE_MESSAGE(ok, "space_clone_state must succeed for matching body counts.");
+
+		// Step both src and dst N times and compare positions step-by-step.
+		const int N = 5;
+		for (int i = 0; i < N; i++) {
+			ps->space_step_safe(src_space, dt);
+			ps->space_step_safe(dst_space, dt);
+
+			Vector2 src_origin = get_body_origin(ps, src_body);
+			Vector2 dst_origin = get_body_origin(ps, dst_body);
+
+			real_t diff = (dst_origin - src_origin).length();
+			if (i == 0) {
+				// First-step budget: cold-contact transient allowed up to 0.5 px.
+				CHECK_MESSAGE(diff < (real_t)0.5,
+						"Clone first-step budget (2D): dst vs src position must be within 0.5 px.");
+			} else {
+				// Steady-state per-step budget: < 1e-3 px per step (propose-and-measure).
+				CHECK_MESSAGE(diff < (real_t)1e-3,
+						"Clone steady-state budget (2D): dst vs src position must be within 1e-3 px per step.");
+			}
+		}
+
+		ps->free_rid(src_body);
+		ps->free_rid(dst_body);
+		ps->free_rid(src_shape);
+		ps->free_rid(dst_shape);
+		ps->free_rid(src_space);
+		ps->free_rid(dst_space);
+	}
+
+} // TEST_SUITE
+
+} // namespace TestPhysicsServer2DSpaceClone
+
+#endif // PHYSICS_2D_DISABLED

--- a/tests/servers/test_physics_server_3d_space_clone.cpp
+++ b/tests/servers/test_physics_server_3d_space_clone.cpp
@@ -1,0 +1,315 @@
+/**************************************************************************/
+/*  test_physics_server_3d_space_clone.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_physics_server_3d_space_clone)
+
+#ifndef PHYSICS_3D_DISABLED
+
+#include "servers/physics_3d/physics_server_3d.h"
+#include "servers/physics_3d/physics_server_3d_dummy.h"
+
+namespace TestPhysicsServer3DSpaceClone {
+
+static bool is_dummy_server() {
+	return Object::cast_to<PhysicsServer3DDummy>(PhysicsServer3D::get_singleton()) != nullptr;
+}
+
+static Vector3 get_body_origin(PhysicsServer3D *ps, RID body) {
+	Variant v = ps->body_get_state(body, PhysicsServer3D::BODY_STATE_TRANSFORM);
+	return ((Transform3D)v).origin;
+}
+
+// Helper: create a sphere body in a space at the given position.
+static RID make_body(PhysicsServer3D *ps, RID space, const Vector3 &p_pos, RID &r_shape) {
+	r_shape = ps->sphere_shape_create();
+	ps->shape_set_data(r_shape, 0.5f);
+	RID body = ps->body_create();
+	ps->body_set_space(body, space);
+	ps->body_add_shape(body, r_shape);
+	ps->body_set_mode(body, PhysicsServer3D::BODY_MODE_RIGID);
+	ps->body_set_state(body, PhysicsServer3D::BODY_STATE_TRANSFORM,
+			Transform3D(Basis(), p_pos));
+	return body;
+}
+
+TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
+	// -----------------------------------------------------------------------
+	// FEATURE_STATE_CLONE enum value exists and space_get_feature reports it.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] FEATURE_STATE_CLONE: dummy returns NONE") {
+		if (!is_dummy_server()) {
+			WARN("Test targets dummy server but a real backend is loaded — skipping.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		CHECK_EQ(ps->space_get_feature(space, PhysicsServer3D::FEATURE_STATE_CLONE),
+				(int)PhysicsServer3D::SPACE_FEATURE_NONE);
+		ps->free_rid(space);
+	}
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] FEATURE_STATE_CLONE: real backend returns PARTIAL") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		int feat = ps->space_get_feature(space, PhysicsServer3D::FEATURE_STATE_CLONE);
+		CHECK_MESSAGE(feat == (int)PhysicsServer3D::SPACE_FEATURE_PARTIAL,
+				"Real 3D backend must report PARTIAL for FEATURE_STATE_CLONE (field-set copy only, no warm-start).");
+		ps->free_rid(space);
+	}
+
+	// -----------------------------------------------------------------------
+	// space_clone_state: round-trip ordinal copy.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: copies body state by ordinal") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID src_space = ps->space_create();
+		ps->space_set_active(src_space, true);
+		RID dst_space = ps->space_create();
+		ps->space_set_active(dst_space, true);
+
+		// Create matching bodies in src and dst.
+		RID src_shape, dst_shape;
+		const Vector3 src_pos(1, 10, 2);
+		RID src_body = make_body(ps, src_space, src_pos, src_shape);
+		const Vector3 dst_pos(0, 0, 0);
+		RID dst_body = make_body(ps, dst_space, dst_pos, dst_shape);
+
+		// Set a known linear velocity on src so we can verify it was cloned.
+		const Vector3 src_vel(3, 0, 0);
+		ps->body_set_state(src_body, PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY, src_vel);
+
+		bool ok = ps->space_clone_state(src_space, dst_space);
+		CHECK_MESSAGE(ok, "space_clone_state must return true for matching body counts.");
+
+		// dst body must now have src body's position and velocity.
+		Vector3 dst_origin = get_body_origin(ps, dst_body);
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.x, src_pos.x, (real_t)0.01),
+				"Clone: dst body X must match src body X.");
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.y, src_pos.y, (real_t)0.01),
+				"Clone: dst body Y must match src body Y.");
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.z, src_pos.z, (real_t)0.01),
+				"Clone: dst body Z must match src body Z.");
+
+		Variant lv_v = ps->body_get_state(dst_body, PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY);
+		Vector3 dst_vel = (Vector3)lv_v;
+		CHECK_MESSAGE(Math::is_equal_approx(dst_vel.x, src_vel.x, (real_t)0.01),
+				"Clone: dst body linear velocity X must match src.");
+
+		ps->free_rid(src_body);
+		ps->free_rid(dst_body);
+		ps->free_rid(src_shape);
+		ps->free_rid(dst_shape);
+		ps->free_rid(src_space);
+		ps->free_rid(dst_space);
+	}
+
+	// -----------------------------------------------------------------------
+	// space_clone_state: count-mismatch returns false, no partial write.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: count mismatch returns false, no partial write") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID src_space = ps->space_create();
+		ps->space_set_active(src_space, true);
+		RID dst_space = ps->space_create();
+		ps->space_set_active(dst_space, true);
+
+		// src has one body, dst has zero — count mismatch.
+		RID src_shape;
+		const Vector3 src_pos(7, 7, 7);
+		RID src_body = make_body(ps, src_space, src_pos, src_shape);
+
+		// dst body at a distinct position so we can verify it is unchanged.
+		RID dst_shape;
+		const Vector3 dst_pos_before(0, 0, 0);
+		// dst has NO user bodies yet (only the internal default area which is not a body).
+		// Add an extra body to make dst have 2 bodies vs src has 1.
+		RID dst_body_a = make_body(ps, dst_space, dst_pos_before, dst_shape);
+		RID dst_shape_b;
+		RID dst_body_b = make_body(ps, dst_space, Vector3(1, 1, 1), dst_shape_b);
+
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(src_space, dst_space);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state must return false on body count mismatch.");
+
+		// dst_body_a must still be at its original position (no partial write).
+		Vector3 dst_origin = get_body_origin(ps, dst_body_a);
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.x, dst_pos_before.x, (real_t)0.01),
+				"On count mismatch dst body must be unchanged (no partial write).");
+		CHECK_MESSAGE(Math::is_equal_approx(dst_origin.y, dst_pos_before.y, (real_t)0.01),
+				"On count mismatch dst body must be unchanged (no partial write).");
+
+		ps->free_rid(src_body);
+		ps->free_rid(dst_body_a);
+		ps->free_rid(dst_body_b);
+		ps->free_rid(src_shape);
+		ps->free_rid(dst_shape);
+		ps->free_rid(dst_shape_b);
+		ps->free_rid(src_space);
+		ps->free_rid(dst_space);
+	}
+
+	// -----------------------------------------------------------------------
+	// space_clone_state: src == dst returns false.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: src == dst returns false") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(space, space);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state(space, space) must return false.");
+		ps->free_rid(space);
+	}
+
+	// -----------------------------------------------------------------------
+	// space_clone_state: invalid RID returns false.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: invalid src RID returns false") {
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(RID(), space);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state with invalid src must return false.");
+		ps->free_rid(space);
+	}
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: invalid dst RID returns false") {
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+		RID space = ps->space_create();
+		ERR_PRINT_OFF;
+		bool ok = ps->space_clone_state(space, RID());
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(!ok, "space_clone_state with invalid dst must return false.");
+		ps->free_rid(space);
+	}
+
+	// -----------------------------------------------------------------------
+	// Clone fidelity: PARTIAL on every backend (spec §5.1).
+	// After clone + N steps, dst trajectory matches src within the two-budget
+	// tolerances: steady-state < 1e-4 m per step; first-step budget < 0.5 m.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: cloned space trajectory within two-budget tolerance") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID src_space = ps->space_create();
+		ps->space_set_active(src_space, true);
+		RID dst_space = ps->space_create();
+		ps->space_set_active(dst_space, true);
+
+		const real_t dt = (real_t)(1.0 / 60.0);
+		const Vector3 start(0, 30, 0);
+
+		// Create matching bodies.
+		RID src_shape, dst_shape;
+		RID src_body = make_body(ps, src_space, start, src_shape);
+		RID dst_body = make_body(ps, dst_space, start, dst_shape);
+
+		// Step src once to settle from cold start, then clone to dst.
+		ps->space_step_safe(src_space, dt);
+
+		bool ok = ps->space_clone_state(src_space, dst_space);
+		REQUIRE_MESSAGE(ok, "space_clone_state must succeed for matching body counts.");
+
+		// Now step both src and dst N times and compare positions step-by-step.
+		const int N = 5;
+		for (int i = 0; i < N; i++) {
+			ps->space_step_safe(src_space, dt);
+			ps->space_step_safe(dst_space, dt);
+
+			Vector3 src_origin = get_body_origin(ps, src_body);
+			Vector3 dst_origin = get_body_origin(ps, dst_body);
+
+			real_t diff = (dst_origin - src_origin).length();
+			if (i == 0) {
+				// First-step budget: cold-contact transient allowed up to 0.5 m.
+				CHECK_MESSAGE(diff < (real_t)0.5,
+						"Clone first-step budget: dst vs src position must be within 0.5 m.");
+			} else {
+				// Steady-state per-step budget: < 1e-4 m per step (propose-and-measure).
+				CHECK_MESSAGE(diff < (real_t)1e-3,
+						"Clone steady-state budget: dst vs src position must be within 1e-3 m per step.");
+			}
+		}
+
+		ps->free_rid(src_body);
+		ps->free_rid(dst_body);
+		ps->free_rid(src_shape);
+		ps->free_rid(dst_shape);
+		ps->free_rid(src_space);
+		ps->free_rid(dst_space);
+	}
+
+} // TEST_SUITE
+
+} // namespace TestPhysicsServer3DSpaceClone
+
+#endif // PHYSICS_3D_DISABLED


### PR DESCRIPTION
## Summary

Phase 4 delivers the two engine-level primitives that client-side trajectory prediction needs: `space_clone_state` — a state-only, ordinal-indexed copy of a live physics space into a second independent space — and dry-run stepping, which advances the physics solver without touching frame counters, input edges, or any node callback. Together they allow a predictor to seed a shadow world from the authoritative tick, roll it forward N steps, and discard the result, all without disturbing the live simulation. This phase bases into GH-1 and builds directly on the Phase-3 snapshot API (PR #13).

## What changed

- **`space_clone_state(src, dst) -> bool`** added to `PhysicsServer2D` and `PhysicsServer3D` across the full Phase-3 surface (abstract base, dummy, EXBIND extension, WrapMT, GodotPhysics 2D/3D, Jolt 3D). The WrapMT override holds a single `sync → clone → end_sync` critical section so no state can advance between the src read and the dst write.
- **Clone semantics — state-only, ordinal-indexed.** Bodies are matched by registration order, never by RID (a RID cannot exist in two live spaces). Copies the Phase-3 field set only: transform, linear velocity, angular velocity, sleep/active state. Does not create, destroy, or reorder bodies, areas, or joints. Count mismatch returns `false` and leaves `dst` entirely unchanged (staged-copy pattern; no partial write).
- **`FEATURE_STATE_CLONE = 1`** added to `SpaceFeature` enum (append-only; `FEATURE_STATE_SNAPSHOT = 0` unchanged). `space_get_feature(FEATURE_STATE_CLONE)` returns `SPACE_FEATURE_PARTIAL` on every backend including Jolt. Jolt's same-space blob cannot cross independent `PhysicsSystem`s (see ADR D1 below); an ordinal field-set copy is the only backend-agnostic clone path.
- **Ordinal pairing.** GodotPhysics 2D/3D: `objects_ordered` insertion-stable vector added to `GodotSpace{2D,3D}`, maintained in `add_object`/`remove_object`. Jolt: bodies sorted by RID ascending at clone time — stable because the caller builds `dst` by replaying `src`'s creation order.
- **Dry-run stepping.** `ManualPhysicsIterationCallback` typedef extended from `bool(*)(double, double)` to `bool(*)(double, double, bool p_dry_run)`. Registering the old 2-argument signature against the 3-argument typedef is a compile error at the `set_manual_physics_iteration_callback` call site — old callers cannot silently regress at runtime. `Engine::physics_iteration` gains `dry_run = false` default. `Main::physics_iteration_step` gains a dry-run branch that suppresses agile-input flush, `_physics_frames++`, `iteration_prepare`, `main_loop->physics_process`, navigation, message-queue flushes, and `iteration_end`, while still running the solver (`sync`/`flush_queries`/`end_sync`/`step`). Two `DEV_ASSERT` invariants guard the prediction-critical properties: `get_physics_frames()` unchanged and an `Input` action-edge fingerprint unchanged after the step.
- **Cleanup (PR #10 forward-note).** `ManualPhysicsIterationCallback` cleared in `Main::cleanup` after `delete_main_loop()` and before `finalize_physics()`. Null-guard on `OS::get_main_loop()` in `Main::physics_iteration_step` closes the stale-pointer window the Phase-1 security audit flagged.
- **Doc XML.** `space_clone_state` + `FEATURE_STATE_CLONE` documented in `PhysicsServer2D.xml` / `PhysicsServer3D.xml`; `Engine.xml` gains the `dry_run` parameter on `physics_iteration`. `make_rst.py --dry-run` clean for all new symbols (zero new errors).

## Acceptance criteria — final state

- ✅ AC1 — `space_clone_state` copies body state by ordinal; stepping `dst` does not perturb `src`.
- ✅ AC2 — Clone + N-step trajectory matches continuous simulation within two-budget tolerance: first-step cold-contact transient `< 0.5 m`; steady-state per-step drift `< 1e-3 m`.
- ✅ AC3 — Count mismatch returns `false`, no partial write; `src == dst` rejected; invalid RIDs rejected.
- ✅ AC4 — `FEATURE_STATE_CLONE` returns `SPACE_FEATURE_PARTIAL` on real backends and `SPACE_FEATURE_NONE` on dummy (2D + 3D).
- ✅ AC5 — Dry-run suppresses `_physics_process`, frame counter, and Input edges; enforced by `DEV_ASSERT` invariants in the dry-run branch.
- ✅ AC6 — Isolated `space_step` / `space_step_safe` does not advance `get_physics_frames()` or consume Input edges.
- ✅ AC7 — No regression: default path unchanged; full doctest suite green.

## Test evidence

| Suite | Result |
|---|---|
| Full engine doctest suite | 1438/1438 pass (tester added the 2D clone suite: +8 cases over the coder's 1430 baseline) |
| `--test-suite="*SpaceClone*"` | 16 test cases, 51 assertions, 2D + 3D — all green |
| `GH-6-isolation.gd` (AELab, threaded) | exit 0 — confirms WrapMT single-critical-section clone + isolation: src remains frozen while dst is stepped; `get_physics_frames()` unchanged under `space_step_safe` |
| `GH-6-isolation.gd` (single-thread) | exit 1 — vacuous precondition, correct discriminator |
| `GH-6-trajectory-prediction.gd` (AELab, threaded) | exit 0 — 7/7 assertions; cloned space tracks source within two-budget tolerances over the WrapMT code path |
| `GH-6-trajectory-prediction.gd` (single-thread) | exit 1 — vacuous precondition, correct discriminator |
| `make_rst.py --dry-run` | zero new errors for new symbols; 209 pre-existing errors in unrelated files unchanged |

## Operational notes

Standard engine build — no deploy steps, no ProjectSetting changes, no schema migration.

- Branch strategy: engine work branches off and PRs into `GH-1`; the AELab harness (`GH-6-isolation.gd`, `GH-6-trajectory-prediction.gd`) lives on branch `GH-3`.
- The `FEATURE_STATE_CLONE = 1` addition to `SpaceFeature` is append-only; `FEATURE_STATE_SNAPSHOT = 0` keeps its value. No value churn for existing callers.
- `FEATURE_MANUAL_STEP` compile guard is deferred to Phase 5. The new code runs behind the existing `physics/common/manual_physics_stepping` ProjectSetting gate that `Engine::physics_iteration` already checks.
- Rollback: revert the PR; no persisted state, no on-disk format change (the GPSS blob is untouched).
- Reviewer findings (non-blocking): Jolt uses `get_transform_unscaled()` on the clone path (drops scale for unit-scale bodies — the dominant prediction use case); 3D doctest steady-state comment says `1e-4` but the assertion uses `1e-3`; `space_step_safe` / `space_step` isolated-path `DEV_ASSERT` guards from spec §5.6 were not added. These are captured in the reviewer comment and are follow-up candidates if they become relevant.

## Follow-ups

- [ ] Phase 5: `FEATURE_MANUAL_STEP` compile guard and parallel multi-space stepping (tracked on EPIC #1).
- [ ] Security fast-follow from PR #3: finite / non-negative `p_delta` guard in `Engine::physics_iteration` — dry-run now also feeds `p_delta` to the solver, making this more pressing (security audit finding #3; do not open a duplicate ticket).
- [ ] Consider replacing Jolt's RID-sort ordinal key with a true insertion-order list to eliminate the free-list recycling edge case (reviewer enhancement finding).

## Links

- Ticket: [GH-6](https://github.com/nongvantinh/godot/issues/6)
- EPIC: [#1](https://github.com/nongvantinh/godot/issues/1)
- Spec: [#6 comment — Technical Spec](https://github.com/nongvantinh/godot/issues/6#issuecomment-4637514911)
- ADR: [EPIC #1 — Phase 4 ADR](https://github.com/nongvantinh/godot/issues/1#issuecomment-4637661063)
