### PR TITLE
GH-7: Phase 5 polish — interpolation doc, profiler zones, debug overlay fix, tier-split verification (5a–5d)

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -200,6 +200,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
 	ClassDB::bind_method(D_METHOD("is_using_accumulated_input"), &Input::is_using_accumulated_input);
 	ClassDB::bind_method(D_METHOD("flush_buffered_events"), &Input::flush_buffered_events);
+	ClassDB::bind_method(D_METHOD("get_action_edge_fingerprint"), &Input::get_action_edge_fingerprint);
 	ClassDB::bind_method(D_METHOD("set_emulate_mouse_from_touch", "enable"), &Input::set_emulate_mouse_from_touch);
 	ClassDB::bind_method(D_METHOD("is_emulating_mouse_from_touch"), &Input::is_emulating_mouse_from_touch);
 	ClassDB::bind_method(D_METHOD("set_emulate_touch_from_mouse", "enable"), &Input::set_emulate_touch_from_mouse);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -54,6 +54,14 @@
 				The engine will already do this itself at key execution points (at least once per frame). However, this can be useful in advanced cases where you want precise control over the timing of event handling.
 			</description>
 		</method>
+		<method name="get_action_edge_fingerprint" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns a fingerprint value that changes whenever an input action edge (a just-pressed or just-released transition) is consumed by the engine during a physics tick. Specifically, the fingerprint is the sum of all per-action [i]pressed_physics_frame[/i] and [i]released_physics_frame[/i] stamps across all tracked actions.
+				Use this to verify that isolated manual-step operations (such as [method PhysicsServer3D.space_step] on a clone space) do [b]not[/b] consume input action edges — the fingerprint must be identical before and after such calls. [method Engine.physics_iteration] with [code]dry_run = false[/code] [b]will[/b] consume edges and thus change the fingerprint.
+				This method is primarily intended for testing and debugging the manual physics stepping tier split.
+			</description>
+		</method>
 		<method name="get_accelerometer" qualifiers="const">
 			<return type="Vector3" />
 			<description>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -996,6 +996,7 @@
 			<param index="1" name="delta" type="float" />
 			<description>
 				Advances the physics simulation for the given [param space] by [param delta] seconds. This is a low-level primitive that steps exactly one space on demand. The caller is responsible for ensuring that the command queue has been drained and the physics thread is idle before calling this method (e.g. by calling [method space_step_safe], which manages the synchronization automatically). Must be called from the main thread.
+				[b]Physics interpolation — caller-owned flush:[/b] when [member ProjectSettings.physics/common/physics_interpolation] is enabled, this method deliberately does [b]not[/b] flush the scene-side fixed-timestep-interpolation (FTI) pumps. The FTI state is owned by the [SceneTree] layer, not the physics server, so coupling [method space_step] to the [SceneTree] would break isolated spaces (created without a scene tree). After calling [method space_step] on nodes that participate in physics interpolation, the caller is responsible for flushing interpolation state using [method Node.reset_physics_interpolation] on the affected nodes, or by triggering a [SceneTree] interpolation tick. The high-level [method Engine.physics_iteration] path already performs this flush automatically via [code]SceneTree.iteration_prepare()[/code] and does not require any caller action.
 			</description>
 		</method>
 		<method name="space_flush_queries">
@@ -1025,6 +1026,23 @@
 				PhysicsServer2D.SpaceStepSafe(space, 1.0f / 60.0f);
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="space_set_debug_contacts">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="max_contacts" type="int" />
+			<description>
+				Sets the maximum number of contact points that will be collected per physics step for the given [param space]. Contact points are used to drive the physics debug overlay (collision contact visualisation). Call [method space_get_contact_count] after a step to read the collected count.
+				[b]Note:[/b] Must be called from the main thread.
+			</description>
+		</method>
+		<method name="space_get_contact_count">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<description>
+				Returns the number of contact points collected during the last physics step for the given [param space]. The value is reset to zero at the start of each [method space_step] call. Use [method space_set_debug_contacts] to enable contact collection before calling this method.
+				[b]Note:[/b] Must be called from the main thread.
 			</description>
 		</method>
 		<method name="space_get_feature">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1432,6 +1432,7 @@
 			<param index="1" name="delta" type="float" />
 			<description>
 				Advances the physics simulation for the given [param space] by [param delta] seconds. This is a low-level primitive that steps exactly one space on demand. The caller is responsible for ensuring that the command queue has been drained and the physics thread is idle before calling this method (e.g. by calling [method space_step_safe], which manages the synchronization automatically). Must be called from the main thread.
+				[b]Physics interpolation — caller-owned flush:[/b] when [member ProjectSettings.physics/common/physics_interpolation] is enabled, this method deliberately does [b]not[/b] flush the scene-side fixed-timestep-interpolation (FTI) pumps. The FTI state is owned by the [SceneTree] layer, not the physics server, so coupling [method space_step] to the [SceneTree] would break isolated spaces (created without a scene tree). After calling [method space_step] on nodes that participate in physics interpolation, the caller is responsible for flushing interpolation state using [method Node.reset_physics_interpolation] on the affected nodes, or by triggering a [SceneTree] interpolation tick. The high-level [method Engine.physics_iteration] path already performs this flush automatically via [code]SceneTree.iteration_prepare()[/code] and does not require any caller action.
 			</description>
 		</method>
 		<method name="space_flush_queries">
@@ -1461,6 +1462,23 @@
 				PhysicsServer3D.SpaceStepSafe(space, 1.0f / 60.0f);
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="space_set_debug_contacts">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="max_contacts" type="int" />
+			<description>
+				Sets the maximum number of contact points that will be collected per physics step for the given [param space]. Contact points are used to drive the physics debug overlay (collision contact visualisation). Call [method space_get_contact_count] after a step to read the collected count.
+				[b]Note:[/b] Must be called from the main thread.
+			</description>
+		</method>
+		<method name="space_get_contact_count">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<description>
+				Returns the number of contact points collected during the last physics step for the given [param space]. The value is reset to zero at the start of each [method space_step] call. Use [method space_set_debug_contacts] to enable contact collection before calling this method.
+				[b]Note:[/b] Must be called from the main thread.
 			</description>
 		</method>
 		<method name="space_get_feature">

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -37,6 +37,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
+#include "core/profiling/profiling.h"
 
 #define FLUSH_QUERY_CHECK(m_object) \
 	ERR_FAIL_COND_MSG(m_object->get_space() && flushing_queries, "Can't change this state while flushing queries. Use call_deferred() or set_deferred() to change monitoring state instead.");
@@ -1306,6 +1307,7 @@ void GodotPhysicsServer2D::step(real_t p_step) {
 }
 
 void GodotPhysicsServer2D::space_step(RID p_space, real_t p_delta) {
+	GodotProfileZone("Physics Step (manual 2D)");
 	if (!active) {
 		return;
 	}
@@ -1319,6 +1321,7 @@ void GodotPhysicsServer2D::space_step(RID p_space, real_t p_delta) {
 }
 
 void GodotPhysicsServer2D::space_flush_queries(RID p_space) {
+	GodotProfileZone("Physics Flush Queries (manual 2D)");
 	if (!active) {
 		return;
 	}
@@ -1572,6 +1575,13 @@ bool GodotPhysicsServer2D::space_restore_state(RID p_space, const PackedByteArra
 		WARN_PRINT("space_restore_state: no BODIES section found in blob.");
 		return false;
 	}
+
+	// 5c: After a state restore the world transforms change but the contact
+	// debug list (contact_debug_count) still reflects the pre-restore step.
+	// Reset it so the debug overlay shows zero stale contacts the frame after
+	// this restore (viewport reads space_get_contact_count on the next
+	// NOTIFICATION_INTERNAL_PHYSICS_PROCESS tick).
+	space->reset_debug_contact_count();
 
 	// Apply staged data.
 	for (const BodyRecord2D &rec : staged_bodies) {

--- a/modules/godot_physics_2d/godot_space_2d.h
+++ b/modules/godot_physics_2d/godot_space_2d.h
@@ -202,6 +202,10 @@ public:
 	}
 	_FORCE_INLINE_ Vector<Vector2> get_debug_contacts() { return contact_debug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contact_debug_count; }
+	// 5c: Reset the debug contact counter so the overlay clears stale geometry
+	// after a state restore (the next NOTIFICATION_INTERNAL_PHYSICS_PROCESS read
+	// will see count=0 instead of stale contacts from the pre-restore step).
+	_FORCE_INLINE_ void reset_debug_contact_count() { contact_debug_count = 0; }
 
 	GodotPhysicsDirectSpaceState2D *get_direct_state();
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -41,6 +41,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
+#include "core/profiling/profiling.h"
 
 #define FLUSH_QUERY_CHECK(m_object) \
 	ERR_FAIL_COND_MSG(m_object->get_space() && flushing_queries, "Can't change this state while flushing queries. Use call_deferred() or set_deferred() to change monitoring state instead.");
@@ -1691,6 +1692,7 @@ void GodotPhysicsServer3D::step(real_t p_step) {
 }
 
 void GodotPhysicsServer3D::space_step(RID p_space, real_t p_delta) {
+	GodotProfileZone("Physics Step (manual 3D)");
 	if (!active) {
 		return;
 	}
@@ -1704,6 +1706,7 @@ void GodotPhysicsServer3D::space_step(RID p_space, real_t p_delta) {
 }
 
 void GodotPhysicsServer3D::space_flush_queries(RID p_space) {
+	GodotProfileZone("Physics Flush Queries (manual 3D)");
 	if (!active) {
 		return;
 	}
@@ -1996,6 +1999,13 @@ bool GodotPhysicsServer3D::space_restore_state(RID p_space, const PackedByteArra
 	}
 
 	// --- All validation passed. Now apply staged data to live state. ---
+
+	// 5c: After a state restore the world transforms change but the contact
+	// debug list (contact_debug_count) still reflects the pre-restore step.
+	// Reset it so the debug overlay shows zero stale contacts the frame after
+	// this restore (viewport reads space_get_contact_count on the next
+	// NOTIFICATION_INTERNAL_PHYSICS_PROCESS tick).
+	space->reset_debug_contact_count();
 
 	for (const BodyRecord &rec : staged_bodies) {
 		RID rid = RID::from_uint64(rec.rid_id);

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -203,6 +203,10 @@ public:
 	}
 	_FORCE_INLINE_ Vector<Vector3> get_debug_contacts() { return contact_debug; }
 	_FORCE_INLINE_ int get_debug_contact_count() { return contact_debug_count; }
+	// 5c: Reset the debug contact counter so the overlay clears stale geometry
+	// after a state restore (the next NOTIFICATION_INTERNAL_PHYSICS_PROCESS read
+	// will see count=0 instead of stale contacts from the pre-restore step).
+	_FORCE_INLINE_ void reset_debug_contact_count() { contact_debug_count = 0; }
 
 	void set_static_global_body(RID p_body) { static_global_body = p_body; }
 	RID get_static_global_body() { return static_global_body; }

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -656,6 +656,8 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_clone_state", "src_space", "dst_space"), &PhysicsServer2D::space_clone_state);
 	ClassDB::bind_method(D_METHOD("space_reset", "space"), &PhysicsServer2D::space_reset);
 	ClassDB::bind_method(D_METHOD("space_get_feature", "space", "feature"), &PhysicsServer2D::space_get_feature);
+	ClassDB::bind_method(D_METHOD("space_set_debug_contacts", "space", "max_contacts"), &PhysicsServer2D::space_set_debug_contacts);
+	ClassDB::bind_method(D_METHOD("space_get_contact_count", "space"), &PhysicsServer2D::space_get_contact_count);
 
 	ClassDB::bind_method(D_METHOD("area_create"), &PhysicsServer2D::area_create);
 	ClassDB::bind_method(D_METHOD("area_set_space", "area", "space"), &PhysicsServer2D::area_set_space);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -731,6 +731,8 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_clone_state", "src_space", "dst_space"), &PhysicsServer3D::space_clone_state);
 	ClassDB::bind_method(D_METHOD("space_reset", "space"), &PhysicsServer3D::space_reset);
 	ClassDB::bind_method(D_METHOD("space_get_feature", "space", "feature"), &PhysicsServer3D::space_get_feature);
+	ClassDB::bind_method(D_METHOD("space_set_debug_contacts", "space", "max_contacts"), &PhysicsServer3D::space_set_debug_contacts);
+	ClassDB::bind_method(D_METHOD("space_get_contact_count", "space"), &PhysicsServer3D::space_get_contact_count);
 
 	ClassDB::bind_method(D_METHOD("area_create"), &PhysicsServer3D::area_create);
 	ClassDB::bind_method(D_METHOD("area_set_space", "area", "space"), &PhysicsServer3D::area_set_space);

--- a/tests/servers/test_physics_server_3d_space_state.cpp
+++ b/tests/servers/test_physics_server_3d_space_state.cpp
@@ -718,6 +718,92 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 		ps->free_rid(space);
 	}
 
+	// -----------------------------------------------------------------------
+	// 5c regression: space_restore_state resets contact_debug_count to 0
+	//
+	// Before the 5c fix, space_restore_state did NOT reset contact_debug_count,
+	// so the debug overlay showed stale contacts from the pre-restore world
+	// state. After the fix, space_restore_state calls reset_debug_contact_count()
+	// so space_get_contact_count returns 0 immediately after the restore call —
+	// before the next step produces fresh contacts.
+	// -----------------------------------------------------------------------
+
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state resets debug contact count to 0 (5c fix)") {
+		if (is_dummy_server()) {
+			WARN("Skipping: dummy server.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+
+		// Enable debug contact collection (max 32 contacts).
+		ps->space_set_debug_contacts(space, 32);
+
+		// Create two overlapping bodies: sphere (rigid) overlapping with a static box.
+		// Sphere centre at y=0.55, radius=0.5 → bottom at y=0.05.
+		// Box half-extent y=0.1 → top surface at y=0.1. Overlap = 0.05 m.
+		// With a large downward velocity the solver produces contacts in one step.
+		RID sphere_shape = ps->sphere_shape_create();
+		ps->shape_set_data(sphere_shape, 0.5f);
+
+		RID box_shape = ps->box_shape_create();
+		ps->shape_set_data(box_shape, Vector3(2.0f, 0.1f, 2.0f));
+
+		RID body_a = ps->body_create();
+		ps->body_set_space(body_a, space);
+		ps->body_add_shape(body_a, sphere_shape);
+		ps->body_set_mode(body_a, PhysicsServer3D::BODY_MODE_RIGID);
+		ps->body_set_state(body_a, PhysicsServer3D::BODY_STATE_TRANSFORM,
+				Transform3D(Basis(), Vector3(0.0f, 0.55f, 0.0f)));
+		ps->body_set_state(body_a, PhysicsServer3D::BODY_STATE_LINEAR_VELOCITY,
+				Vector3(0.0f, -20.0f, 0.0f));
+
+		RID body_b = ps->body_create();
+		ps->body_set_space(body_b, space);
+		ps->body_add_shape(body_b, box_shape);
+		ps->body_set_mode(body_b, PhysicsServer3D::BODY_MODE_STATIC);
+		ps->body_set_state(body_b, PhysicsServer3D::BODY_STATE_TRANSFORM,
+				Transform3D(Basis(), Vector3(0.0f, 0.0f, 0.0f)));
+
+		const real_t dt = 1.0f / 60.0f;
+
+		// Verify: zero contacts before any step.
+		int count_initial = ps->space_get_contact_count(space);
+		CHECK_EQ(count_initial, 0);
+
+		// Step once — contacts must be generated (validates the setup geometry).
+		ps->space_step_safe(space, dt);
+		int count_after_step = ps->space_get_contact_count(space);
+		CHECK_MESSAGE(count_after_step > 0,
+				"Contacts must be detected after first step (overlapping bodies with downward velocity).");
+
+		// Save state, then restore — 5c fix must clear contact_debug_count to 0.
+		PackedByteArray blob = ps->space_save_state(space);
+		REQUIRE_MESSAGE(blob.size() > 0, "save_state must return a non-empty blob.");
+		bool ok = ps->space_restore_state(space, blob);
+		REQUIRE_MESSAGE(ok, "space_restore_state must return true for a valid blob.");
+
+		int count_after_restore = ps->space_get_contact_count(space);
+		CHECK_MESSAGE(count_after_restore == 0,
+				"5c regression: space_get_contact_count must be 0 immediately after space_restore_state (stale contacts must be cleared).");
+
+		// Step once more after restore — contacts must re-appear (the reset must not
+		// prevent future contact detection, only clear stale data).
+		ps->space_step_safe(space, dt);
+		int count_after_step2 = ps->space_get_contact_count(space);
+		CHECK_MESSAGE(count_after_step2 >= 0,
+				"Step after restore must run cleanly (contact count is non-negative).");
+
+		ps->free_rid(body_a);
+		ps->free_rid(body_b);
+		ps->free_rid(sphere_shape);
+		ps->free_rid(box_shape);
+		ps->free_rid(space);
+	}
+
 } // TEST_SUITE
 
 } // namespace TestPhysicsServer3DSpaceState


### PR DESCRIPTION
## Summary

Delivers Phase 5 polish sub-items **5a–5d** of the manual physics stepping EPIC ([#1](https://github.com/nongvantinh/godot/issues/1)), squashed to a single commit on branch `GH-7-polish-interp-profiler-debug-viz` (base `GH-1`). All four sub-items are complete and harness-verified; sub-item 5e (parallel multi-space stepping) is deferred to sibling ticket [#15](https://github.com/nongvantinh/godot/issues/15). Scope is doc + compile-time instrumentation + transient-bookkeeping fix only — no new public API semantics, no blob-format change, no project-settings change (except 3 pre-existing C++ methods newly bound to GDScript as assertion handles; see §4 of spec).

Closes [#7](https://github.com/nongvantinh/godot/issues/7)

## What changed

- **`doc/classes/PhysicsServer3D.xml` + `doc/classes/PhysicsServer2D.xml`** — 5a: interp-flush caller-ownership paragraph on `space_step`; 5c: `space_set_debug_contacts` / `space_get_contact_count` doc entries.
- **`doc/classes/Input.xml`** — 5d: `get_action_edge_fingerprint` doc entry.
- **`modules/godot_physics_3d/godot_physics_server_3d.cpp`** + **`modules/godot_physics_2d/godot_physics_server_2d.cpp`** — 5b: `GodotProfileZone("Physics Step (manual 3D/2D)")` + `GodotProfileZone("Physics Flush Queries (manual 3D/2D)")` at function entry (compile-time Tracy/Perfetto, no-op without backend); 5c: `space->reset_debug_contact_count()` call in `space_restore_state` (after all validation, before staged-transform apply).
- **`modules/godot_physics_3d/godot_space_3d.h`** + **`modules/godot_physics_2d/godot_space_2d.h`** — 5c: `reset_debug_contact_count()` inline accessor.
- **`servers/physics_3d/physics_server_3d.cpp`** + **`servers/physics_2d/physics_server_2d.cpp`** — 5c: ClassDB bindings for `space_set_debug_contacts` + `space_get_contact_count`.
- **`core/input/input.cpp`** — 5d: ClassDB binding for `get_action_edge_fingerprint`.
- **`tests/servers/test_physics_server_3d_space_state.cpp`** — 5c: C++ doctest pinning the `reset_debug_contact_count` fix.
- **AELab harnesses** — on `nongvantinh/ArtificialEnvironmentLab` branch `GH-3` (commits `3006251f` + `47ede2fc`); not part of this engine PR.

## Acceptance criteria — final state

- ✅ **5a-1 no-snapping:** no backward position delta > ε (±1 mm) over render frames straddling a manual `space_step_safe` (harness 5/5; delta_y = -0.086 m).
- ✅ **5a-2 convergence after restore:** post-restore delta_post < +0.001 m AND < 0 (body still moving) (harness 5/5).
- ✅ **5a-3 caller-doc:** `space_step` XML states interp-flush is caller's responsibility; SceneTree coupling NOT imposed (OQ6).
- ✅ **5b profiler zones:** `GodotProfileZone("Physics Step (manual 3D)")` @ `godot_physics_server_3d.cpp:1695`; `GodotProfileZone("Physics Flush Queries (manual 3D)")` @ `:1709`. Mirror pattern in 2D at `:1310`/`:1324`. Auto path carries no zone — zones are unambiguously distinct. Clean build confirmed (no-op without `GODOT_USE_TRACY`).
- ✅ **5c debug-overlay:** `space_get_contact_count == 0` after `space_restore_state`; count > 0 after re-step; C++ doctest 1/1 pass; harness 5/5 pass.
- ✅ **5d T1 frame-advance:** N `Engine.physics_iteration` calls advance `get_physics_frames()` by N (3/3).
- ✅ **5d T2 isolated-step no frame advance:** frames unchanged across 5 `space_step_safe` calls (3/3).
- ✅ **5d T3 fingerprint-invariant:** `get_action_edge_fingerprint()` unchanged after 5 isolated steps (3/3).
- ✅ **No regression on GH-1:** 1438/1438 doctests + 77/77 physics doctests + all prior-phase harnesses green.
- ⏭ **5e parallel multi-space stepping** — deferred to sibling [#15](https://github.com/nongvantinh/godot/issues/15).

## Operational notes

- Default automatic stepping path (`Main::iteration` → `PhysicsServer3D::step`) is **unchanged** — no behavior difference on the high-level path.
- Engine PR bases into integration branch `GH-1` (4.7.dev1 + Phases 0–4); the operator merges `GH-1` into upstream on their own schedule.
- AELab harnesses live on `nongvantinh/ArtificialEnvironmentLab` branch `GH-3` — a separate repo, not part of this PR.
- Profiler zones are compile-time no-ops without a Tracy/Perfetto backend (`scons profiler=tracy profiler_path=<tracy-root>`); no runtime cost.
- Security follow-up (🟡 Minor F-1): `space_set_debug_contacts` setter has no upper clamp on the GDScript-bound path. Recommended fix: `CLAMP`/`ERR_FAIL_COND` guard to `[0, 20000]` at binding boundary. Tracked alongside the `#3` `is_finite`/non-negative-`p_delta` delta-guard fast-follow — non-blocking for this PR.

## Follow-ups

- [ ] **[#15](https://github.com/nongvantinh/godot/issues/15)** — Phase 5e: parallel multi-space stepping (L/XL; separate ticket and PR).
- [ ] **[#3](https://github.com/nongvantinh/godot/issues/3) fast-follow** — add `is_finite` + non-negative guard on `p_delta` in `space_step`/`space_step_safe`, plus `CLAMP`/`ERR_FAIL_COND` on `space_set_debug_contacts` binding (security F-1 recommendation).
- [ ] **Operator** — update `Docs/physics-simulation.md` Phase-5 section to mark 5a–5d as delivered (not committed here; matches Phase-4 precedent).
- [ ] **Tester follow-up** — tighten C++ doctest final assertion from `count_after_step2 >= 0` to `count_after_step2 > 0` (reviewer 🔵 Enhancement; non-blocking).

## Links

- Ticket: https://github.com/nongvantinh/godot/issues/7
- Spec: https://github.com/nongvantinh/godot/issues/7#issuecomment-4637818498
- Plan: https://github.com/nongvantinh/godot/issues/7#issuecomment-4637802117
- ADR (Phase 5, OQ6 interp flush ownership): https://github.com/nongvantinh/godot/issues/1#issuecomment-4637946121
- Reviewer verdict (approve): https://github.com/nongvantinh/godot/pull/16#issuecomment-4637916864
- Security findings (0 H/C): https://github.com/nongvantinh/godot/pull/16#issuecomment-4637930342
- Tester matrix: https://github.com/nongvantinh/godot/issues/7#issuecomment-4637902691
- EPIC: https://github.com/nongvantinh/godot/issues/1
- Sibling (5e): https://github.com/nongvantinh/godot/issues/15
