### PR TITLE
feat(physics): GH-15 Phase 5e — space_step_batch + isolated-space concurrent stepping

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -1006,6 +1006,36 @@
 				Flushes deferred query callbacks (e.g. body-entered/body-exited signals) for the given [param space]. Equivalent to one iteration of the per-space flush that the automatic physics loop performs each frame. Must be called from the main thread.
 			</description>
 		</method>
+		<method name="space_step_batch">
+			<return type="void" />
+			<param index="0" name="spaces" type="RID[]" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Advances N physics spaces by [param delta] seconds under a single main-thread handshake. Batched stepping eliminates the per-space [code]sync()[/code]/[code]end_sync()[/code] rendezvous cost: all spaces are stepped inside one bracket, serially in array order.
+				[b]Contract (batched-under-one-handshake, main-thread):[/b] Must be called from the main thread; guarded by [code]ERR_FAIL_COND_MSG(!Thread::is_main_thread(), ...)[/code] (same rationale as [method space_step_safe]). Empty [param spaces] array is a no-op — no [code]sync()[/code]/[code]end_sync()[/code] handshake is performed. Duplicate RIDs are each stepped as given (no deduplication); appearing twice means stepped twice. An invalid or null RID is skipped with a logged error; the batch continues and the [code]sync[/code]/[code]end_sync[/code] bracket is never left half-open.
+				Does not advance [method Engine.get_physics_frames] (consistent with [method space_step]).
+				[codeblocks]
+				[gdscript]
+				var spaces: Array[RID] = []
+				for i in range(4):
+				    var s = PhysicsServer2D.space_create()
+				    PhysicsServer2D.space_set_active(s, true)
+				    spaces.append(s)
+				# Advance all 4 spaces under one sync/end_sync bracket.
+				PhysicsServer2D.space_step_batch(spaces, 1.0 / 60.0)
+				[/gdscript]
+				[csharp]
+				var spaces = new Godot.Collections.Array&lt;Rid&gt;();
+				for (int i = 0; i &lt; 4; i++) {
+				    var s = PhysicsServer2D.SpaceCreate();
+				    PhysicsServer2D.SpaceSetActive(s, true);
+				    spaces.Add(s);
+				}
+				PhysicsServer2D.SpaceStepBatch(spaces, 1.0f / 60.0f);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="space_step_safe">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1442,6 +1442,36 @@
 				Flushes deferred query callbacks (e.g. body-entered/body-exited signals) for the given [param space]. Equivalent to one iteration of the per-space flush that the automatic physics loop performs each frame. Must be called from the main thread.
 			</description>
 		</method>
+		<method name="space_step_batch">
+			<return type="void" />
+			<param index="0" name="spaces" type="RID[]" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Advances N physics spaces by [param delta] seconds under a single main-thread handshake. Batched stepping eliminates the per-space [code]sync()[/code]/[code]end_sync()[/code] rendezvous cost: all spaces are stepped inside one bracket, serially in array order.
+				[b]Contract (batched-under-one-handshake, main-thread):[/b] Must be called from the main thread; guarded by [code]ERR_FAIL_COND_MSG(!Thread::is_main_thread(), ...)[/code] (same rationale as [method space_step_safe]). Empty [param spaces] array is a no-op — no [code]sync()[/code]/[code]end_sync()[/code] handshake is performed. Duplicate RIDs are each stepped as given (no deduplication); appearing twice means stepped twice. An invalid or null RID is skipped with a logged error; the batch continues and the [code]sync[/code]/[code]end_sync[/code] bracket is never left half-open.
+				Does not advance [method Engine.get_physics_frames] (consistent with [method space_step]).
+				[codeblocks]
+				[gdscript]
+				var spaces: Array[RID] = []
+				for i in range(4):
+				    var s = PhysicsServer3D.space_create()
+				    PhysicsServer3D.space_set_active(s, true)
+				    spaces.append(s)
+				# Advance all 4 spaces under one sync/end_sync bracket.
+				PhysicsServer3D.space_step_batch(spaces, 1.0 / 60.0)
+				[/gdscript]
+				[csharp]
+				var spaces = new Godot.Collections.Array&lt;Rid&gt;();
+				for (int i = 0; i &lt; 4; i++) {
+				    var s = PhysicsServer3D.SpaceCreate();
+				    PhysicsServer3D.SpaceSetActive(s, true);
+				    spaces.Add(s);
+				}
+				PhysicsServer3D.SpaceStepBatch(spaces, 1.0f / 60.0f);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="space_step_safe">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1315,6 +1315,11 @@ void GodotPhysicsServer2D::space_step(RID p_space, real_t p_delta) {
 	GodotSpace2D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
+	// #3 delta guard: covers direct space_step plus space_step_safe/space_step_batch,
+	// which funnel through this method. Reject NaN/Inf/negative before the solver.
+	ERR_FAIL_COND_MSG(!Math::is_finite(p_delta) || p_delta < 0,
+			"space_step: delta must be finite and non-negative.");
+
 	_update_shapes();
 
 	stepper->step(space, p_delta);

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1700,6 +1700,11 @@ void GodotPhysicsServer3D::space_step(RID p_space, real_t p_delta) {
 	GodotSpace3D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
+	// #3 delta guard: covers direct space_step plus space_step_safe/space_step_batch,
+	// which funnel through this method. Reject NaN/Inf/negative before the solver.
+	ERR_FAIL_COND_MSG(!Math::is_finite(p_delta) || p_delta < 0,
+			"space_step: delta must be finite and non-negative.");
+
 	_update_shapes();
 
 	stepper->step(space, p_delta);

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -201,6 +201,15 @@ void JoltPhysicsServer3D::space_set_active(RID p_space, bool p_active) {
 	JoltSpace3D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
+	// Symmetric counterpart to the space_make_isolated()/space_step_isolated() guards (AC8):
+	// an isolated space is stepped thread-direct via space_step_isolated() and must never
+	// also be driven by the main-thread server loop. Allowing both would run two
+	// PhysicsSystem::Update() calls against the same space concurrently — the exact race the
+	// per-space JobSystem/TempAllocator split was introduced to avoid.
+	ERR_FAIL_COND_MSG(p_active && space->get_is_isolated(),
+			"Cannot activate an isolated space: it is stepped thread-direct via space_step_isolated() "
+			"and must not also be added to active_spaces. (AC8)");
+
 	if (p_active) {
 		space->set_active(true);
 		active_spaces.insert(space);
@@ -1645,6 +1654,12 @@ void JoltPhysicsServer3D::space_step(RID p_space, real_t p_delta) {
 	JoltSpace3D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
 
+	// #3 delta guard: a caller-supplied delta reaches the Jolt solver here (and via
+	// space_step_safe/space_step_batch, which funnel through this method). Reject
+	// NaN/Inf/negative before it hits PhysicsSystem::Update.
+	ERR_FAIL_COND_MSG(!Math::is_finite(p_delta) || p_delta < 0,
+			"space_step: delta must be finite and non-negative.");
+
 	job_system->pre_step();
 	space->step((float)p_delta);
 	job_system->post_step();
@@ -1661,6 +1676,40 @@ void JoltPhysicsServer3D::space_flush_queries(RID p_space) {
 	flushing_queries = true;
 	space->call_queries();
 	flushing_queries = false;
+}
+
+void JoltPhysicsServer3D::space_make_isolated(RID p_space) {
+	JoltSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	ERR_FAIL_COND_MSG(active_spaces.has(space),
+			"space_make_isolated must not be called on a space that has been added to active_spaces "
+			"(i.e. passed to space_set_active(true)). (AC8)");
+	space->make_isolated();
+}
+
+void JoltPhysicsServer3D::space_step_isolated(RID p_space, real_t p_delta) {
+	// D2 (GH-15): thread-direct step for isolated Jolt spaces.
+	// This method bypasses WrapMT entirely and is callable from a worker thread.
+	// It MUST NOT be called on live (non-isolated) spaces — that would bypass the
+	// WrapMT main-thread guard that protects the live command queue (AC8).
+	ERR_FAIL_COND_MSG(!active, "JoltPhysicsServer3D is not active.");
+
+	JoltSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+
+	ERR_FAIL_COND_MSG(!space->get_is_isolated(),
+			"space_step_isolated must only be called on isolated spaces (never in active_spaces). "
+			"Call JoltSpace3D::make_isolated() before using this path. (AC8)");
+
+	// #3 delta guard: this path bypasses space_step(), so it needs its own check —
+	// reject NaN/Inf/negative before space->step() reaches PhysicsSystem::Update.
+	ERR_FAIL_COND_MSG(!Math::is_finite(p_delta) || p_delta < 0,
+			"space_step_isolated: delta must be finite and non-negative.");
+
+	// The space owns its per-space JobSystemSingleThreaded and TempAllocatorMalloc —
+	// no shared-static job list, no shared bump-state temp allocator.
+	// No pre_step()/post_step() from the server-shared JoltJobSystem.
+	space->step((float)p_delta);
 }
 
 // Blob format constants shared by save/restore.
@@ -1914,13 +1963,15 @@ bool JoltPhysicsServer3D::space_clone_state(RID p_src_space, RID p_dst_space) {
 	}
 
 	// Stage all source state before writing any destination body (no partial write).
-	struct BodyState {
+	// Named StagedBodyState (not BodyState) to avoid shadowing the inherited
+	// PhysicsServer3D::BodyState enum (-Wshadow).
+	struct StagedBodyState {
 		Transform3D transform;
 		Vector3 linear_velocity;
 		Vector3 angular_velocity;
 		bool sleeping;
 	};
-	LocalVector<BodyState> staged;
+	LocalVector<StagedBodyState> staged;
 	staged.resize(src_bodies.size());
 	for (uint32_t i = 0; i < src_bodies.size(); i++) {
 		staged[i].transform = src_bodies[i]->get_transform_unscaled();

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -430,6 +430,13 @@ public:
 
 	virtual void space_step(RID p_space, real_t p_delta) override;
 	virtual void space_flush_queries(RID p_space) override;
+
+	// D2 (GH-15): thread-direct stepping for isolated Jolt spaces only.
+	// Bypasses WrapMT entirely; callable from a worker thread.
+	// The space must have been promoted via space_make_isolated() before calling.
+	// AC8: the WrapMT live-space guard is NOT relaxed; this path is only for isolated spaces.
+	void space_make_isolated(RID p_space);
+	void space_step_isolated(RID p_space, real_t p_delta);
 	virtual PackedByteArray space_save_state(RID p_space) override;
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override;
 	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override;

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -185,6 +185,32 @@ JoltSpace3D::~JoltSpace3D() {
 		delete layers;
 		layers = nullptr;
 	}
+
+	// D2 (GH-15): destroy per-space resources for isolated spaces.
+	if (isolated_temp_allocator != nullptr) {
+		delete isolated_temp_allocator;
+		isolated_temp_allocator = nullptr;
+	}
+	if (isolated_job_system != nullptr) {
+		delete isolated_job_system;
+		isolated_job_system = nullptr;
+	}
+}
+
+void JoltSpace3D::make_isolated() {
+	if (is_isolated) {
+		return; // Already isolated — no-op.
+	}
+	// Create per-space JobSystemSingleThreaded (avoids JoltJobSystem::Job::completed_head
+	// inline static std::atomic, which is process-global and races under concurrent Update).
+	isolated_job_system = new JPH::JobSystemSingleThreaded();
+	isolated_job_system->Init(JPH::cMaxPhysicsJobs);
+	// Use malloc-backed allocator (avoids JoltTempAllocator unsynchronized bump state).
+	isolated_temp_allocator = new JPH::TempAllocatorMalloc();
+	// Swap the pointers used by step().
+	job_system = isolated_job_system;
+	temp_allocator = isolated_temp_allocator;
+	is_isolated = true;
 }
 
 void JoltSpace3D::step(float p_step) {

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -35,6 +35,7 @@
 #include <Jolt/Jolt.h>
 
 #include <Jolt/Core/JobSystem.h>
+#include <Jolt/Core/JobSystemSingleThreaded.h>
 #include <Jolt/Core/TempAllocator.h>
 #include <Jolt/Physics/Body/BodyInterface.h>
 #include <Jolt/Physics/Collision/BroadPhase/BroadPhaseQuery.h>
@@ -70,6 +71,17 @@ class JoltSpace3D {
 
 	JPH::JobSystem *job_system = nullptr;
 	JPH::TempAllocator *temp_allocator = nullptr;
+
+	// D2 (GH-15): per-space private job-system and temp-allocator for isolated spaces.
+	// Owned exclusively by this space; destroyed with it. Null for live (non-isolated) spaces.
+	JPH::JobSystemSingleThreaded *isolated_job_system = nullptr;
+	JPH::TempAllocatorMalloc *isolated_temp_allocator = nullptr;
+
+	// True when this space owns its own job-system/temp-allocator and may be stepped
+	// directly from a worker thread via JoltPhysicsServer3D::space_step_isolated().
+	// A space that has been passed to space_set_active(true) is NEVER isolated (AC8).
+	bool is_isolated = false;
+
 	JoltLayers *layers = nullptr;
 	JoltContactListener3D *contact_listener = nullptr;
 	JoltBodyActivationListener3D *body_activation_listener = nullptr;
@@ -98,6 +110,14 @@ public:
 
 	bool is_active() const { return active; }
 	void set_active(bool p_active) { active = p_active; }
+
+	// D2 (GH-15): isolated-space thread-direct stepping support.
+	bool get_is_isolated() const { return is_isolated; }
+	// Promote this space to isolated mode: allocate per-space job-system and
+	// temp-allocator so the space can be stepped directly from a worker thread.
+	// Must only be called on a space that has never been added to active_spaces
+	// (i.e. never passed to space_set_active(true)).  No-op if already isolated.
+	void make_isolated();
 
 	bool is_stepping() const { return stepping; }
 

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -651,6 +651,7 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_step", "space", "delta"), &PhysicsServer2D::space_step);
 	ClassDB::bind_method(D_METHOD("space_flush_queries", "space"), &PhysicsServer2D::space_flush_queries);
 	ClassDB::bind_method(D_METHOD("space_step_safe", "space", "delta"), &PhysicsServer2D::space_step_safe);
+	ClassDB::bind_method(D_METHOD("space_step_batch", "spaces", "delta"), &PhysicsServer2D::space_step_batch);
 	ClassDB::bind_method(D_METHOD("space_save_state", "space"), &PhysicsServer2D::space_save_state);
 	ClassDB::bind_method(D_METHOD("space_restore_state", "space", "state"), &PhysicsServer2D::space_restore_state);
 	ClassDB::bind_method(D_METHOD("space_clone_state", "src_space", "dst_space"), &PhysicsServer2D::space_clone_state);
@@ -923,6 +924,21 @@ void PhysicsServer2D::space_step_safe(RID p_space, real_t p_delta) {
 	sync();
 	space_flush_queries(p_space);
 	space_step(p_space, p_delta);
+	end_sync();
+}
+
+void PhysicsServer2D::space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta) {
+	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "space_step_batch must be called from the main thread.");
+	if (p_spaces.is_empty()) {
+		return; // AC7: empty array -> no-op, no handshake.
+	}
+	sync();
+	for (int i = 0; i < p_spaces.size(); i++) {
+		RID r = p_spaces[i];
+		ERR_CONTINUE(!r.is_valid());
+		space_flush_queries(r);
+		space_step(r, p_delta);
+	}
 	end_sync();
 }
 

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -618,6 +618,7 @@ public:
 	virtual void space_step(RID p_space, real_t p_delta) = 0;
 	virtual void space_flush_queries(RID p_space) = 0;
 	virtual void space_step_safe(RID p_space, real_t p_delta);
+	virtual void space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta);
 
 	enum SpaceFeature {
 		FEATURE_STATE_SNAPSHOT = 0,

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/variant/typed_array.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
 class PhysicsDirectBodyState2DDummy : public PhysicsDirectBodyState2D {
@@ -345,6 +346,7 @@ public:
 
 	virtual void space_step(RID p_space, real_t p_delta) override {}
 	virtual void space_flush_queries(RID p_space) override {}
+	virtual void space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta) override {}
 	virtual PackedByteArray space_save_state(RID p_space) override { return PackedByteArray(); }
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override { return false; }
 	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override { return false; }

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -33,6 +33,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
+#include "core/variant/typed_array.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
 #define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
@@ -132,6 +133,20 @@ public:
 		physics_server_2d->space_flush_queries(p_space);
 		physics_server_2d->space_step(p_space, p_delta);
 		end_sync();
+	}
+	virtual void space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta) override {
+		ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "space_step_batch must be called from the main thread.");
+		if (p_spaces.is_empty()) {
+			return; // AC7: empty array -> no-op, no handshake.
+		}
+		sync(); // ONE rendezvous for all N spaces
+		for (int i = 0; i < p_spaces.size(); i++) {
+			RID r = p_spaces[i];
+			ERR_CONTINUE(!r.is_valid());
+			physics_server_2d->space_flush_queries(r);
+			physics_server_2d->space_step(r, p_delta);
+		}
+		end_sync(); // ONE close
 	}
 	virtual PackedByteArray space_save_state(RID p_space) override {
 		ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), PackedByteArray(),

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -726,6 +726,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_step", "space", "delta"), &PhysicsServer3D::space_step);
 	ClassDB::bind_method(D_METHOD("space_flush_queries", "space"), &PhysicsServer3D::space_flush_queries);
 	ClassDB::bind_method(D_METHOD("space_step_safe", "space", "delta"), &PhysicsServer3D::space_step_safe);
+	ClassDB::bind_method(D_METHOD("space_step_batch", "spaces", "delta"), &PhysicsServer3D::space_step_batch);
 	ClassDB::bind_method(D_METHOD("space_save_state", "space"), &PhysicsServer3D::space_save_state);
 	ClassDB::bind_method(D_METHOD("space_restore_state", "space", "state"), &PhysicsServer3D::space_restore_state);
 	ClassDB::bind_method(D_METHOD("space_clone_state", "src_space", "dst_space"), &PhysicsServer3D::space_clone_state);
@@ -1158,6 +1159,21 @@ void PhysicsServer3D::space_step_safe(RID p_space, real_t p_delta) {
 	sync();
 	space_flush_queries(p_space);
 	space_step(p_space, p_delta);
+	end_sync();
+}
+
+void PhysicsServer3D::space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta) {
+	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "space_step_batch must be called from the main thread.");
+	if (p_spaces.is_empty()) {
+		return; // AC7: empty array -> no-op, no handshake.
+	}
+	sync();
+	for (int i = 0; i < p_spaces.size(); i++) {
+		RID r = p_spaces[i];
+		ERR_CONTINUE(!r.is_valid());
+		space_flush_queries(r);
+		space_step(r, p_delta);
+	}
 	end_sync();
 }
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -821,6 +821,7 @@ public:
 	virtual void space_step(RID p_space, real_t p_delta) = 0;
 	virtual void space_flush_queries(RID p_space) = 0;
 	virtual void space_step_safe(RID p_space, real_t p_delta);
+	virtual void space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta);
 
 	enum SpaceFeature {
 		FEATURE_STATE_SNAPSHOT = 0,

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/variant/typed_array.h"
 #include "servers/physics_3d/physics_server_3d.h"
 
 class PhysicsDirectBodyState3DDummy : public PhysicsDirectBodyState3D {
@@ -439,6 +440,7 @@ public:
 
 	virtual void space_step(RID p_space, real_t p_delta) override {}
 	virtual void space_flush_queries(RID p_space) override {}
+	virtual void space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta) override {}
 	virtual PackedByteArray space_save_state(RID p_space) override { return PackedByteArray(); }
 	virtual bool space_restore_state(RID p_space, const PackedByteArray &p_state) override { return false; }
 	virtual bool space_clone_state(RID p_src_space, RID p_dst_space) override { return false; }

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -33,6 +33,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
+#include "core/variant/typed_array.h"
 #include "servers/physics_3d/physics_server_3d.h"
 
 #define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
@@ -138,6 +139,20 @@ public:
 		physics_server_3d->space_flush_queries(p_space);
 		physics_server_3d->space_step(p_space, p_delta);
 		end_sync();
+	}
+	virtual void space_step_batch(const TypedArray<RID> &p_spaces, real_t p_delta) override {
+		ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "space_step_batch must be called from the main thread.");
+		if (p_spaces.is_empty()) {
+			return; // AC7: empty array -> no-op, no handshake.
+		}
+		sync(); // ONE rendezvous for all N spaces
+		for (int i = 0; i < p_spaces.size(); i++) {
+			RID r = p_spaces[i];
+			ERR_CONTINUE(!r.is_valid());
+			physics_server_3d->space_flush_queries(r);
+			physics_server_3d->space_step(r, p_delta);
+		}
+		end_sync(); // ONE close
 	}
 	virtual PackedByteArray space_save_state(RID p_space) override {
 		ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), PackedByteArray(),
@@ -464,6 +479,11 @@ public:
 	int get_process_info(ProcessInfo p_info) override {
 		return physics_server_3d->get_process_info(p_info);
 	}
+
+	// D2 (GH-15): expose the inner server for isolated-space thread-direct stepping.
+	// Only for use in tests/specialized paths that hold the inner pointer and know
+	// not to call live-space methods from off the main thread.
+	PhysicsServer3D *get_inner_server() const { return physics_server_3d; }
 
 	PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread);
 	~PhysicsServer3DWrapMT();

--- a/tests/servers/test_jolt_space_step_isolated.cpp
+++ b/tests/servers/test_jolt_space_step_isolated.cpp
@@ -1,0 +1,368 @@
+/**************************************************************************/
+/*  test_jolt_space_step_isolated.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+// GH-15 D2 kill-gate: per-space job-system + temp-allocator concurrent-step test.
+//
+// WHAT THIS TESTS (AC6):
+//   N independent JoltSpace3D instances, each constructed with its own
+//   JPH::JobSystemSingleThreaded + JPH::TempAllocatorMalloc.  Each space is
+//   stepped from a separate worker thread for STEPS iterations.  Under TSan
+//   there must be no data races; under ASan no heap errors.
+//
+//   The per-space private systems avoid two known shared-static race conditions:
+//     1. JoltJobSystem::Job::completed_head — inline static std::atomic (process-global).
+//     2. JoltTempAllocator — unsynchronized bump allocator (top/base fields).
+//
+//   Both JoltPhysicsServer3D::space_make_isolated() and space_step_isolated()
+//   use the same technique internally; this test exercises the underlying physics
+//   primitives directly (following the pattern in test_jolt_space_state.h) so
+//   it runs regardless of which server backend is active.
+//
+// TWO-BUDGET TOLERANCE (Phase-4 convention):
+//   After STEPS iterations all cold-contact transients have settled.
+//   We compare each thread-stepped space end-Y against an identical serial run
+//   within STEADY_STATE_BUDGET = 1e-3 m.  Float non-determinism across threads
+//   is not expected for deterministic single-threaded job system; the budget is
+//   a safety net only.
+//
+// AC8: the WrapMT live-space main-thread guard is tested separately in
+//   test_physics_server_3d_space_step.cpp.
+
+#include "tests/test_macros.h"
+
+#include "modules/modules_enabled.gen.h" // For MODULE_JOLT_PHYSICS_ENABLED.
+
+TEST_FORCE_LINK(test_jolt_space_step_isolated)
+
+#if !defined(PHYSICS_3D_DISABLED) && defined(MODULE_JOLT_PHYSICS_ENABLED)
+
+#include "core/object/worker_thread_pool.h"
+#include "servers/physics_3d/physics_server_3d.h"
+#include "servers/physics_3d/physics_server_3d_wrap_mt.h"
+
+#include "modules/jolt_physics/jolt_physics_server_3d.h"
+#include "modules/jolt_physics/jolt_project_settings.h"
+#include "modules/jolt_physics/spaces/jolt_broad_phase_layer.h"
+#include "modules/jolt_physics/spaces/jolt_space_3d.h"
+
+#include <Jolt/Jolt.h>
+
+#include <Jolt/Core/JobSystemSingleThreaded.h>
+#include <Jolt/Core/TempAllocator.h>
+#include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Jolt/Physics/Collision/Shape/BoxShape.h>
+#include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/PhysicsSystem.h>
+
+namespace TestJoltSpaceStepIsolated {
+
+// Number of concurrent spaces (= worker threads in the concurrent test).
+static const int N = 4;
+// Steps per space.
+static const int STEPS = 100;
+// Time step (60 Hz).
+static const float DT = 1.0f / 60.0f;
+// Phase-4 steady-state budget after STEPS iterations (m).
+static const float STEADY_STATE_BUDGET = 1e-3f;
+
+// Helper: returns the inner JoltPhysicsServer3D if the singleton wraps one.
+// Returns nullptr if the active server is not Jolt (e.g. GodotPhysics3D).
+static JoltPhysicsServer3D *get_jolt_server() {
+	PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+	PhysicsServer3DWrapMT *wrap = Object::cast_to<PhysicsServer3DWrapMT>(ps);
+	PhysicsServer3D *inner = (wrap != nullptr) ? wrap->get_inner_server() : ps;
+	return Object::cast_to<JoltPhysicsServer3D>(inner);
+}
+
+// Per-space bundle: private job system + allocator + JoltSpace3D + body IDs.
+// Each bundle is fully independent from every other bundle; no shared state.
+struct SpaceBundle {
+	JPH::JobSystemSingleThreaded job_sys;
+	JPH::TempAllocatorMalloc temp_alloc;
+	JoltSpace3D *space = nullptr;
+	JPH::BodyID sphere_id;
+	JPH::BodyID floor_id;
+
+	// step_physics() pattern from test_jolt_space_state.h:
+	//   Clear listeners (avoid Godot-object callbacks on raw Jolt bodies),
+	//   call physics_system.Update() N times, then restore listeners.
+	static void step_space(JPH::PhysicsSystem &p_phys,
+			JPH::TempAllocatorMalloc &p_alloc,
+			JPH::JobSystemSingleThreaded &p_js,
+			int p_count) {
+		JPH::ContactListener *saved_contact = p_phys.GetContactListener();
+		JPH::SoftBodyContactListener *saved_soft = p_phys.GetSoftBodyContactListener();
+		JPH::BodyActivationListener *saved_activation = p_phys.GetBodyActivationListener();
+		p_phys.SetContactListener(nullptr);
+		p_phys.SetSoftBodyContactListener(nullptr);
+		p_phys.SetBodyActivationListener(nullptr);
+
+		for (int i = 0; i < p_count; i++) {
+			p_phys.Update(DT, 1, &p_alloc, &p_js);
+		}
+
+		p_phys.SetContactListener(saved_contact);
+		p_phys.SetSoftBodyContactListener(saved_soft);
+		p_phys.SetBodyActivationListener(saved_activation);
+	}
+
+	// Set up the JoltSpace3D with a static floor and a dynamic sphere.
+	// The sphere starts at (0, start_y, 0) and falls under gravity.
+	bool setup(float p_start_y) {
+		job_sys.Init(JPH::cMaxPhysicsJobs);
+		space = new JoltSpace3D(&job_sys, &temp_alloc);
+
+		JPH::PhysicsSystem &phys = space->get_physics_system();
+		phys.SetGravity(JPH::Vec3(0.0f, -9.8f, 0.0f));
+		JPH::BodyInterface &iface = phys.GetBodyInterface();
+
+		const JPH::ObjectLayer layer_static =
+				space->map_to_object_layer(JoltBroadPhaseLayer::BODY_STATIC, 1, 1);
+		const JPH::ObjectLayer layer_dynamic =
+				space->map_to_object_layer(JoltBroadPhaseLayer::BODY_DYNAMIC, 1, 1);
+
+		// Static floor.
+		JPH::BoxShapeSettings floor_ss(JPH::Vec3(50.0f, 0.5f, 50.0f));
+		floor_ss.SetEmbedded();
+		JPH::ShapeSettings::ShapeResult floor_res = floor_ss.Create();
+		if (!floor_res.IsValid()) {
+			return false;
+		}
+		floor_id = iface.CreateAndAddBody(
+				JPH::BodyCreationSettings(floor_res.Get(),
+						JPH::RVec3(0.0f, -0.5f, 0.0f), JPH::Quat::sIdentity(),
+						JPH::EMotionType::Static, layer_static),
+				JPH::EActivation::DontActivate);
+		if (floor_id.IsInvalid()) {
+			return false;
+		}
+
+		// Dynamic sphere (falls under gravity, hits floor).
+		JPH::SphereShapeSettings sphere_ss(0.5f);
+		sphere_ss.SetEmbedded();
+		JPH::ShapeSettings::ShapeResult sphere_res = sphere_ss.Create();
+		if (!sphere_res.IsValid()) {
+			return false;
+		}
+		sphere_id = iface.CreateAndAddBody(
+				JPH::BodyCreationSettings(sphere_res.Get(),
+						JPH::RVec3(0.0f, p_start_y, 0.0f), JPH::Quat::sIdentity(),
+						JPH::EMotionType::Dynamic, layer_dynamic),
+				JPH::EActivation::Activate);
+		return !sphere_id.IsInvalid();
+	}
+
+	float sphere_y() const {
+		return space->get_physics_system().GetBodyInterface().GetCenterOfMassPosition(sphere_id).GetY();
+	}
+
+	void teardown() {
+		delete space;
+		space = nullptr;
+	}
+};
+
+TEST_SUITE("[JoltPhysics][SpaceStep][D2]") {
+	// D2 KILL-GATE:
+	// N isolated spaces, each stepped by its own worker thread for STEPS iterations.
+	// No TSan/ASan errors = D2 survives the kill gate.
+	// End-state Y compared to serial oracle (identical initial conditions).
+	TEST_CASE("[JoltPhysics][GH-15] isolated concurrent step matches serial oracle (D2 kill-gate)") {
+		REQUIRE_MESSAGE(JoltProjectSettings::max_bodies > 0,
+				"JoltProjectSettings::max_bodies is 0 — Jolt module not initialized; skipping.");
+
+		const float start_ys[N] = { 50.0f, 60.0f, 70.0f, 80.0f };
+
+		// ------------------------------------------------------------------
+		// Serial oracle: step each space on the main thread.
+		// ------------------------------------------------------------------
+		float oracle_y[N];
+		for (int i = 0; i < N; i++) {
+			SpaceBundle oracle;
+			REQUIRE_MESSAGE(oracle.setup(start_ys[i]),
+					vformat("Oracle space %d: body setup failed.", i));
+			SpaceBundle::step_space(oracle.space->get_physics_system(),
+					oracle.temp_alloc, oracle.job_sys, STEPS);
+			oracle_y[i] = oracle.sphere_y();
+			oracle.teardown();
+		}
+
+		// ------------------------------------------------------------------
+		// Concurrent: N spaces, each stepped by a separate worker thread.
+		// TSan must report zero races; ASan must report zero heap errors.
+		// ------------------------------------------------------------------
+		SpaceBundle bundles[N];
+		for (int i = 0; i < N; i++) {
+			REQUIRE_MESSAGE(bundles[i].setup(start_ys[i]),
+					vformat("D2 space %d: body setup failed.", i));
+		}
+
+		struct WorkItem {
+			SpaceBundle *bundle;
+			static void run(void *p_ud) {
+				WorkItem *self = static_cast<WorkItem *>(p_ud);
+				SpaceBundle::step_space(
+						self->bundle->space->get_physics_system(),
+						self->bundle->temp_alloc,
+						self->bundle->job_sys,
+						STEPS);
+			}
+		};
+		WorkItem work[N];
+		WorkerThreadPool::TaskID tids[N];
+		for (int i = 0; i < N; i++) {
+			work[i] = { &bundles[i] };
+			tids[i] = WorkerThreadPool::get_singleton()->add_native_task(
+					&WorkItem::run, &work[i], false);
+		}
+		for (int i = 0; i < N; i++) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(tids[i]);
+		}
+
+		// Compare end positions to serial oracle within STEADY_STATE_BUDGET.
+		for (int i = 0; i < N; i++) {
+			float thread_y = bundles[i].sphere_y();
+			float diff = Math::abs(thread_y - oracle_y[i]);
+			CHECK_MESSAGE(diff < STEADY_STATE_BUDGET,
+					vformat("D2 space %d: thread Y=%.6f vs oracle Y=%.6f diff=%.6f >= budget %.3f",
+							i, thread_y, oracle_y[i], diff, STEADY_STATE_BUDGET));
+		}
+
+		for (int i = 0; i < N; i++) {
+			bundles[i].teardown();
+		}
+	}
+
+	// AC8 (server-level): space_step_isolated rejects a live (non-isolated) space.
+	TEST_CASE("[JoltPhysics][GH-15] space_step_isolated rejects live space (AC8)") {
+		JoltPhysicsServer3D *jolt = get_jolt_server();
+		if (jolt == nullptr) {
+			WARN_MESSAGE(false, "Skipping: active backend is not JoltPhysicsServer3D.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true); // live space — NOT isolated
+
+		// space_step_isolated on a live space must ERR_FAIL, not crash (AC8).
+		ERR_PRINT_OFF;
+		jolt->space_step_isolated(space, DT);
+		ERR_PRINT_ON;
+
+		ps->space_set_active(space, false);
+		ps->free_rid(space);
+	}
+
+	// AC8 (server-level): space_make_isolated + space_step_isolated succeed
+	// for an inactive space.
+	TEST_CASE("[JoltPhysics][GH-15] space_make_isolated + space_step_isolated succeed") {
+		JoltPhysicsServer3D *jolt = get_jolt_server();
+		if (jolt == nullptr) {
+			WARN_MESSAGE(false, "Skipping: active backend is not JoltPhysicsServer3D.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		// Not isolated yet: step_isolated must ERR_FAIL (not crash, AC8).
+		ERR_PRINT_OFF;
+		jolt->space_step_isolated(space, DT);
+		ERR_PRINT_ON;
+
+		// Promote to isolated; step_isolated must now succeed cleanly.
+		jolt->space_make_isolated(space);
+		jolt->space_step_isolated(space, DT);
+
+		ps->free_rid(space);
+	}
+
+	// AC8 (F2 hardening): space_set_active(true) must reject an already-isolated space —
+	// the symmetric counterpart to space_make_isolated() rejecting active spaces. Without
+	// this guard a caller could make a space both isolated AND live, so it would be stepped
+	// thread-direct via space_step_isolated() AND by the main-thread server loop — two
+	// concurrent PhysicsSystem::Update() calls on one space.
+	TEST_CASE("[JoltPhysics][GH-15] space_set_active(true) rejects an isolated space (AC8/F2)") {
+		JoltPhysicsServer3D *jolt = get_jolt_server();
+		if (jolt == nullptr) {
+			WARN_MESSAGE(false, "Skipping: active backend is not JoltPhysicsServer3D.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		jolt->space_make_isolated(space);
+
+		// Activating an isolated space must ERR_FAIL (not crash) and must NOT activate it.
+		ERR_PRINT_OFF;
+		ps->space_set_active(space, true);
+		ERR_PRINT_ON;
+
+		// The space stays inactive: reachable only thread-direct, never via the main loop.
+		CHECK_FALSE(ps->space_is_active(space));
+
+		ps->free_rid(space);
+	}
+
+	// #3 delta guard: space_step_isolated bypasses space_step(), so it carries its own
+	// finite/non-negative delta check — a bad delta must ERR_FAIL, not reach the solver.
+	TEST_CASE("[JoltPhysics][GH-15] space_step_isolated rejects non-finite / negative delta (#3)") {
+		JoltPhysicsServer3D *jolt = get_jolt_server();
+		if (jolt == nullptr) {
+			WARN_MESSAGE(false, "Skipping: active backend is not JoltPhysicsServer3D.");
+			return;
+		}
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		jolt->space_make_isolated(space);
+
+		// Bad deltas must be rejected without crashing or stepping.
+		ERR_PRINT_OFF;
+		jolt->space_step_isolated(space, Math::NaN);
+		jolt->space_step_isolated(space, Math::INF);
+		jolt->space_step_isolated(space, -1.0f);
+		ERR_PRINT_ON;
+
+		// A valid delta still steps cleanly.
+		jolt->space_step_isolated(space, DT);
+
+		ps->free_rid(space);
+	}
+
+} // TEST_SUITE
+
+} // namespace TestJoltSpaceStepIsolated
+
+#endif // !PHYSICS_3D_DISABLED && MODULE_JOLT_PHYSICS_ENABLED

--- a/tests/servers/test_physics_server_2d_space_clone.cpp
+++ b/tests/servers/test_physics_server_2d_space_clone.cpp
@@ -82,7 +82,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] FEATURE_STATE_CLONE: dummy returns NONE") {
 		if (!is_dummy_server()) {
-			WARN("Test targets dummy server but a real backend is loaded — skipping.");
+			MESSAGE("Test targets dummy server but a real backend is loaded — skipping.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -95,7 +95,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] FEATURE_STATE_CLONE: real backend returns PARTIAL") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -115,7 +115,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: copies body state by ordinal") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -176,7 +176,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: count mismatch returns false, no partial write") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -225,7 +225,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: src == dst returns false") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -275,7 +275,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_clone_state: cloned space trajectory within two-budget tolerance") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();

--- a/tests/servers/test_physics_server_2d_space_state.cpp
+++ b/tests/servers/test_physics_server_2d_space_state.cpp
@@ -58,7 +58,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
 		REQUIRE(ps != nullptr);
 		if (!is_dummy_server()) {
-			WARN("Test targets dummy server but a real backend is loaded — skipping.");
+			MESSAGE("Test targets dummy server but a real backend is loaded — skipping.");
 			return;
 		}
 		RID space = ps->space_create();
@@ -69,7 +69,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_get_feature returns at-least-PARTIAL for real backend") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -88,7 +88,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_save_state returns non-empty blob for live space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -115,7 +115,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state round-trip restores body state") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -163,7 +163,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_reset detaches all bodies without freeing RIDs") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -201,7 +201,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 	// This test FAILS against the iter-1 buggy reset (which detached everything).
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_reset preserves infrastructure: space is functional after reset") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -253,7 +253,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects empty blob") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -267,7 +267,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects wrong magic") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -289,7 +289,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 		// This tests that a 3D blob is rejected by the 2D server.
 		// We manually craft a minimal blob with dim=3 and valid magic/version/backend.
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -310,7 +310,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects section length exceeding buffer") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -339,7 +339,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects wrong version") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -363,7 +363,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects non-zero reserved byte") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -387,7 +387,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects truncated blob") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
@@ -424,7 +424,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_restore_state rejects backend id mismatch") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();

--- a/tests/servers/test_physics_server_2d_space_step.cpp
+++ b/tests/servers/test_physics_server_2d_space_step.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_physics_server_2d_space_step)
 #include "core/config/engine.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
+#include "core/variant/typed_array.h"
 #include "servers/physics_2d/physics_server_2d.h"
 #include "servers/physics_2d/physics_server_2d_dummy.h"
 
@@ -60,7 +61,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step advances a body under gravity") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -95,7 +96,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_flush_queries is callable on an active space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -115,7 +116,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step does not advance get_physics_frames") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -173,7 +174,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_safe does not leave server in flushing state") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -197,7 +198,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 	// AC: 2D space_step advances only the named space, not other spaces.
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step advances only the named space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -254,7 +255,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 	// AC: GodotPhysics 2D parity — one space_step == one automatic step iteration.
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step parity with one automatic step iteration") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -315,7 +316,7 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 	// The precise MT blocker is the same as documented in the 3D counterpart.
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_safe observes submitted body state (drain invariant)") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -351,10 +352,199 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 		ps->free_rid(space);
 	}
 
+	// -----------------------------------------------------------------------
+	// GH-15 tests — space_step_batch (D1: batched contract + oracle, 2D)
+	// -----------------------------------------------------------------------
+
+	// AC4 + AC2: batch end-state identical to serial space_step_safe loop, same dt (2D).
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_batch parity with serial space_step_safe loop") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		const int N = 4;
+		const int STEPS = 100;
+		const real_t dt = 1.0f / 60.0f;
+
+		// --- Serial reference ---
+		RID serial_spaces[N], serial_shapes[N], serial_bodies[N];
+		Vector2 serial_end[N];
+
+		for (int i = 0; i < N; i++) {
+			serial_spaces[i] = ps->space_create();
+			ps->space_set_active(serial_spaces[i], true);
+			serial_shapes[i] = ps->circle_shape_create();
+			ps->shape_set_data(serial_shapes[i], 16.0f);
+			serial_bodies[i] = ps->body_create();
+			ps->body_set_space(serial_bodies[i], serial_spaces[i]);
+			ps->body_add_shape(serial_bodies[i], serial_shapes[i]);
+			ps->body_set_mode(serial_bodies[i], PhysicsServer2D::BODY_MODE_RIGID);
+			ps->body_set_state(serial_bodies[i], PhysicsServer2D::BODY_STATE_TRANSFORM,
+					Transform2D(0.0f, Vector2(0, -2000.0f - i * 100.0f)));
+		}
+
+		for (int s = 0; s < STEPS; s++) {
+			for (int i = 0; i < N; i++) {
+				ps->space_step_safe(serial_spaces[i], dt);
+			}
+		}
+		for (int i = 0; i < N; i++) {
+			serial_end[i] = get_body_pos(ps, serial_bodies[i]);
+		}
+
+		// --- Batch path ---
+		RID batch_spaces[N], batch_shapes[N], batch_bodies[N];
+		for (int i = 0; i < N; i++) {
+			batch_spaces[i] = ps->space_create();
+			ps->space_set_active(batch_spaces[i], true);
+			batch_shapes[i] = ps->circle_shape_create();
+			ps->shape_set_data(batch_shapes[i], 16.0f);
+			batch_bodies[i] = ps->body_create();
+			ps->body_set_space(batch_bodies[i], batch_spaces[i]);
+			ps->body_add_shape(batch_bodies[i], batch_shapes[i]);
+			ps->body_set_mode(batch_bodies[i], PhysicsServer2D::BODY_MODE_RIGID);
+			ps->body_set_state(batch_bodies[i], PhysicsServer2D::BODY_STATE_TRANSFORM,
+					Transform2D(0.0f, Vector2(0, -2000.0f - i * 100.0f)));
+		}
+
+		TypedArray<RID> space_arr;
+		for (int i = 0; i < N; i++) {
+			space_arr.push_back(batch_spaces[i]);
+		}
+		for (int s = 0; s < STEPS; s++) {
+			ps->space_step_batch(space_arr, dt);
+		}
+
+		// Compare within steady-state budget (< 1e-3 m / 1 px in 2D units).
+		for (int i = 0; i < N; i++) {
+			Vector2 batch_end = get_body_pos(ps, batch_bodies[i]);
+			real_t diff = (batch_end - serial_end[i]).length();
+			CHECK_MESSAGE(diff < (real_t)1.0,
+					"2D space_step_batch end-state must match serial space_step_safe within 1px tolerance.");
+		}
+
+		// Teardown
+		for (int i = 0; i < N; i++) {
+			ps->free_rid(serial_bodies[i]);
+			ps->free_rid(serial_shapes[i]);
+			ps->free_rid(serial_spaces[i]);
+			ps->free_rid(batch_bodies[i]);
+			ps->free_rid(batch_shapes[i]);
+			ps->free_rid(batch_spaces[i]);
+		}
+	}
+
+	// AC7: 2D space_step_batch empty array — no-op, no crash.
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_batch empty array is a no-op") {
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		TypedArray<RID> empty;
+		CHECK_FALSE(ps->is_flushing_queries());
+		ps->space_step_batch(empty, 1.0f / 60.0f);
+		CHECK_FALSE(ps->is_flushing_queries());
+	}
+
+	// AC7: 2D space_step_batch with invalid RID — skips cleanly.
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_batch invalid RID is skipped") {
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		TypedArray<RID> arr;
+		arr.push_back(RID());
+		ERR_PRINT_OFF;
+		ps->space_step_batch(arr, 1.0f / 60.0f);
+		ERR_PRINT_ON;
+		CHECK_FALSE(ps->is_flushing_queries());
+	}
+
+	// AC7: 2D space_step_batch with duplicate RIDs — each occurrence stepped (no dedup).
+	// A single body stepped twice in one batch must have moved further than stepped once.
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_batch duplicate RID is stepped twice") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		RID shape = ps->circle_shape_create();
+		ps->shape_set_data(shape, 16.0f);
+		RID body = ps->body_create();
+		ps->body_set_space(body, space);
+		ps->body_add_shape(body, shape);
+		ps->body_set_mode(body, PhysicsServer2D::BODY_MODE_RIGID);
+		ps->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM,
+				Transform2D(0.0f, Vector2(0, -2000)));
+
+		const real_t dt = 1.0f / 60.0f;
+
+		// Baseline: one step.
+		Vector2 pos_before = get_body_pos(ps, body);
+		ps->space_step_safe(space, dt);
+		Vector2 pos_after_one = get_body_pos(ps, body);
+		// Body under gravity must have moved after one step.
+		CHECK(pos_after_one != pos_before);
+
+		// Reset position.
+		ps->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM,
+				Transform2D(0.0f, Vector2(0, -2000)));
+
+		// Batch with duplicate: same space twice -> two steps.
+		TypedArray<RID> dup;
+		dup.push_back(space);
+		dup.push_back(space);
+		ps->space_step_batch(dup, dt);
+		Vector2 pos_after_two = get_body_pos(ps, body);
+
+		// Two steps must differ from one step (body under gravity moves more in 2 steps).
+		CHECK_MESSAGE(pos_after_two != pos_after_one,
+				"space_step_batch with duplicate RID must step space twice (different position than single step).");
+
+		ps->free_rid(body);
+		ps->free_rid(shape);
+		ps->free_rid(space);
+	}
+
+	// AC8: 2D space_step_batch from non-main thread returns clean error.
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_step_batch from non-main thread returns clean error") {
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		TypedArray<RID> arr;
+		arr.push_back(space);
+
+		struct OffThreadWork {
+			PhysicsServer2D *ps;
+			TypedArray<RID> arr;
+			static void run(void *p_ud) {
+				OffThreadWork *self = static_cast<OffThreadWork *>(p_ud);
+				ERR_PRINT_OFF;
+				self->ps->space_step_batch(self->arr, 1.0f / 60.0f);
+				ERR_PRINT_ON;
+			}
+		} work{ ps, arr };
+
+		WorkerThreadPool::TaskID tid = WorkerThreadPool::get_singleton()->add_native_task(
+				&OffThreadWork::run, &work, false);
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(tid);
+
+		CHECK_FALSE(ps->is_flushing_queries());
+		ps->free_rid(space);
+	}
+
 	// AC: 2D space_step called from a non-main thread returns clean error and does not crash.
 	TEST_CASE("[SceneTree][PhysicsServer2D] space_step from non-main thread returns clean error") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -397,6 +587,48 @@ TEST_SUITE("[PhysicsServer2D][SpaceStep]") {
 
 		ps->free_rid(body);
 		ps->free_rid(shape);
+		ps->free_rid(space);
+	}
+
+	// #3 delta guard: a non-finite or negative delta must be rejected (no step), not
+	// forwarded to the solver. Covers space_step and, transitively, space_step_safe.
+	TEST_CASE("[SceneTree][PhysicsServer2D] space_step rejects non-finite / negative delta (#3)") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+
+		RID circle_shape = ps->circle_shape_create();
+		ps->shape_set_data(circle_shape, 16.0f);
+
+		RID body = ps->body_create();
+		ps->body_set_space(body, space);
+		ps->body_add_shape(body, circle_shape);
+		ps->body_set_mode(body, PhysicsServer2D::BODY_MODE_RIGID);
+		ps->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM, Transform2D(0.0f, Vector2(0, -200)));
+
+		const Vector2 pos_start = get_body_pos(ps, body);
+
+		// Bad deltas must be rejected (ERR_FAIL), leaving the body untouched.
+		ERR_PRINT_OFF;
+		ps->space_step_safe(space, Math::NaN);
+		ps->space_step_safe(space, Math::INF);
+		ps->space_step_safe(space, -1.0f);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(get_body_pos(ps, body) == pos_start, "A non-finite/negative delta must not advance the body.");
+
+		// A valid delta still steps normally (proves the body is otherwise movable).
+		ps->space_step_safe(space, 1.0f / 60.0f);
+		CHECK_MESSAGE(get_body_pos(ps, body) != pos_start, "A valid delta must still advance the body.");
+
+		ps->free_rid(body);
+		ps->free_rid(circle_shape);
 		ps->free_rid(space);
 	}
 

--- a/tests/servers/test_physics_server_3d_space_clone.cpp
+++ b/tests/servers/test_physics_server_3d_space_clone.cpp
@@ -68,7 +68,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] FEATURE_STATE_CLONE: dummy returns NONE") {
 		if (!is_dummy_server()) {
-			WARN("Test targets dummy server but a real backend is loaded — skipping.");
+			MESSAGE("Test targets dummy server but a real backend is loaded — skipping.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -81,7 +81,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] FEATURE_STATE_CLONE: real backend returns PARTIAL") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -100,7 +100,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: copies body state by ordinal") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -153,7 +153,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: count mismatch returns false, no partial write") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -206,7 +206,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: src == dst returns false") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -254,7 +254,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceClone]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_clone_state: cloned space trajectory within two-budget tolerance") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();

--- a/tests/servers/test_physics_server_3d_space_state.cpp
+++ b/tests/servers/test_physics_server_3d_space_state.cpp
@@ -63,7 +63,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
 		REQUIRE(ps != nullptr);
 		if (!is_dummy_server()) {
-			WARN("Test targets dummy server but a real backend is loaded — skipping.");
+			MESSAGE("Test targets dummy server but a real backend is loaded — skipping.");
 			return;
 		}
 		RID space = ps->space_create();
@@ -74,7 +74,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_get_feature returns at-least-PARTIAL for real backend") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -93,7 +93,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_save_state returns non-empty blob for live space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -118,7 +118,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_save_state returns empty for NONE-feature backend") {
 		if (!is_dummy_server()) {
-			WARN("Skipping: not dummy server.");
+			MESSAGE("Skipping: not dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -137,7 +137,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state round-trip restores body state") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -187,7 +187,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_reset detaches all bodies without freeing RIDs") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -236,7 +236,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 	// This test FAILS against the iter-1 buggy reset (which detached everything).
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_reset preserves infrastructure: space is functional after reset") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -289,7 +289,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects empty blob") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -303,7 +303,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects sub-header blob") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -320,7 +320,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects wrong magic") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -341,7 +341,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects wrong version") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -361,7 +361,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects non-zero reserved byte") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -381,7 +381,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects section length exceeding buffer") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -406,7 +406,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects truncated blob") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -439,7 +439,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state leaves space untouched on bad blob") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -485,7 +485,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 		// GodotPhysics 3D must report PARTIAL.
 		// Only meaningful when a real backend is active.
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -540,7 +540,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 		// written/read) because after restore the body would continue from the diverged
 		// position rather than returning to the save-point trajectory.
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -635,7 +635,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects dimension mismatch (2D blob into 3D)") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -660,7 +660,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state rejects backend id mismatch") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -686,7 +686,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_save_state from non-main thread returns clean error") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -730,7 +730,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceState]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_restore_state resets debug contact count to 0 (5c fix)") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy server.");
+			MESSAGE("Skipping: dummy server.");
 			return;
 		}
 		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();

--- a/tests/servers/test_physics_server_3d_space_step.cpp
+++ b/tests/servers/test_physics_server_3d_space_step.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_physics_server_3d_space_step)
 #include "core/config/engine.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
+#include "core/variant/typed_array.h"
 #include "servers/physics_3d/physics_server_3d.h"
 #include "servers/physics_3d/physics_server_3d_dummy.h"
 #include "servers/physics_3d/physics_server_3d_wrap_mt.h"
@@ -61,7 +62,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step advances a body under gravity") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -96,7 +97,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_flush_queries is callable on an active space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -116,7 +117,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step does not advance get_physics_frames") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -174,7 +175,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_safe does not leave server in flushing state") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -200,7 +201,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 	// AC: space_step only advances the named space, not other spaces.
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step advances only the named space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -260,7 +261,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 	// exists must not trigger query callbacks registered on space B.
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_flush_queries flushes only the named space") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -292,7 +293,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 	// Both must produce the same post-step body Y position.
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step parity with one automatic step iteration") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 		// This parity test only applies to GodotPhysics; skip for Jolt (which has
@@ -361,7 +362,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 	//  which is only possible if flush + step ran in the right order.)
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_safe sync->flush->step->end_sync ordering invariant") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -428,7 +429,7 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 	//   — [CommandQueue] Test Queue Basics with WorkerThreadPool sync.
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_safe observes submitted body state (Q-D single-thread drain path)") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -471,10 +472,231 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 		ps->free_rid(space);
 	}
 
+	// -----------------------------------------------------------------------
+	// GH-15 tests — space_step_batch (D1: batched contract + oracle)
+	// -----------------------------------------------------------------------
+
+	// AC4 + AC2: batch end-state identical to serial space_step loop, same dt (3D).
+	// N=4 spaces, 100 steps; each space has one rigid body under gravity.
+	// space_step_batch must produce positions within floating-point noise of the
+	// equivalent serial space_step_safe loop on identical initial conditions.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_batch parity with serial space_step_safe loop") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		const int N = 4;
+		const int STEPS = 100;
+		const real_t dt = 1.0f / 60.0f;
+
+		// --- Serial reference: step each space independently via space_step_safe ---
+		RID serial_spaces[N], serial_shapes[N], serial_bodies[N];
+		Vector3 serial_end[N];
+
+		for (int i = 0; i < N; i++) {
+			serial_spaces[i] = ps->space_create();
+			ps->space_set_active(serial_spaces[i], true);
+			serial_shapes[i] = ps->sphere_shape_create();
+			ps->shape_set_data(serial_shapes[i], 0.5f);
+			serial_bodies[i] = ps->body_create();
+			ps->body_set_space(serial_bodies[i], serial_spaces[i]);
+			ps->body_add_shape(serial_bodies[i], serial_shapes[i]);
+			ps->body_set_mode(serial_bodies[i], PhysicsServer3D::BODY_MODE_RIGID);
+			ps->body_set_state(serial_bodies[i], PhysicsServer3D::BODY_STATE_TRANSFORM,
+					Transform3D(Basis(), Vector3(0, 200.0f + i * 10.0f, 0)));
+		}
+
+		for (int s = 0; s < STEPS; s++) {
+			for (int i = 0; i < N; i++) {
+				ps->space_step_safe(serial_spaces[i], dt);
+			}
+		}
+		for (int i = 0; i < N; i++) {
+			serial_end[i] = get_body_y(ps, serial_bodies[i]) *
+					Vector3(0, 1, 0); // capture full origin
+			Variant v = ps->body_get_state(serial_bodies[i], PhysicsServer3D::BODY_STATE_TRANSFORM);
+			serial_end[i] = ((Transform3D)v).origin;
+		}
+
+		// --- Batch path: same initial conditions, stepped via space_step_batch ---
+		RID batch_spaces[N], batch_shapes[N], batch_bodies[N];
+		for (int i = 0; i < N; i++) {
+			batch_spaces[i] = ps->space_create();
+			ps->space_set_active(batch_spaces[i], true);
+			batch_shapes[i] = ps->sphere_shape_create();
+			ps->shape_set_data(batch_shapes[i], 0.5f);
+			batch_bodies[i] = ps->body_create();
+			ps->body_set_space(batch_bodies[i], batch_spaces[i]);
+			ps->body_add_shape(batch_bodies[i], batch_shapes[i]);
+			ps->body_set_mode(batch_bodies[i], PhysicsServer3D::BODY_MODE_RIGID);
+			ps->body_set_state(batch_bodies[i], PhysicsServer3D::BODY_STATE_TRANSFORM,
+					Transform3D(Basis(), Vector3(0, 200.0f + i * 10.0f, 0)));
+		}
+
+		TypedArray<RID> space_arr;
+		for (int i = 0; i < N; i++) {
+			space_arr.push_back(batch_spaces[i]);
+		}
+		for (int s = 0; s < STEPS; s++) {
+			ps->space_step_batch(space_arr, dt);
+		}
+
+		// Compare: batch end-state must match serial end-state within tolerance.
+		// Two-budget tolerance reused from Phase-4 (steady-state budget < 1e-3 m).
+		for (int i = 0; i < N; i++) {
+			Variant v = ps->body_get_state(batch_bodies[i], PhysicsServer3D::BODY_STATE_TRANSFORM);
+			Vector3 batch_end = ((Transform3D)v).origin;
+			real_t diff = (batch_end - serial_end[i]).length();
+			CHECK_MESSAGE(diff < (real_t)1e-3,
+					"space_step_batch end-state must match serial space_step_safe within steady-state budget.");
+		}
+
+		// Teardown
+		for (int i = 0; i < N; i++) {
+			ps->free_rid(serial_bodies[i]);
+			ps->free_rid(serial_shapes[i]);
+			ps->free_rid(serial_spaces[i]);
+			ps->free_rid(batch_bodies[i]);
+			ps->free_rid(batch_shapes[i]);
+			ps->free_rid(batch_spaces[i]);
+		}
+	}
+
+	// AC7: space_step_batch with empty array — no-op, no crash, server not in flushing state.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_batch empty array is a no-op") {
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		TypedArray<RID> empty;
+		CHECK_FALSE(ps->is_flushing_queries());
+		ps->space_step_batch(empty, 1.0f / 60.0f);
+		CHECK_FALSE(ps->is_flushing_queries());
+	}
+
+	// AC7: space_step_batch with invalid RID — skips cleanly, no crash.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_batch invalid RID is skipped") {
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		TypedArray<RID> arr;
+		arr.push_back(RID()); // null RID
+		ERR_PRINT_OFF;
+		ps->space_step_batch(arr, 1.0f / 60.0f);
+		ERR_PRINT_ON;
+		CHECK_FALSE(ps->is_flushing_queries());
+	}
+
+	// AC7: space_step_batch with duplicate RIDs — each occurrence stepped (no dedup).
+	// A single body stepped twice in one batch must have moved further than stepped once.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_batch duplicate RID is stepped twice") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		RID shape = ps->sphere_shape_create();
+		ps->shape_set_data(shape, 0.5f);
+		RID body = ps->body_create();
+		ps->body_set_space(body, space);
+		ps->body_add_shape(body, shape);
+		ps->body_set_mode(body, PhysicsServer3D::BODY_MODE_RIGID);
+		ps->body_set_state(body, PhysicsServer3D::BODY_STATE_TRANSFORM,
+				Transform3D(Basis(), Vector3(0, 100, 0)));
+
+		const real_t dt = 1.0f / 60.0f;
+
+		// Baseline: one step
+		real_t y_before = get_body_y(ps, body);
+		ps->space_step_safe(space, dt);
+		real_t y_after_one = get_body_y(ps, body);
+		// Body under gravity must have dropped after one step.
+		CHECK(y_after_one < y_before);
+
+		// Reset position
+		ps->body_set_state(body, PhysicsServer3D::BODY_STATE_TRANSFORM,
+				Transform3D(Basis(), Vector3(0, 100, 0)));
+
+		// Batch with duplicate: same space twice -> two steps
+		TypedArray<RID> dup;
+		dup.push_back(space);
+		dup.push_back(space);
+		ps->space_step_batch(dup, dt);
+		real_t y_after_two = get_body_y(ps, body);
+
+		// Two steps must move further than one step (body under gravity).
+		CHECK_MESSAGE(y_after_two < y_after_one,
+				"space_step_batch with duplicate RID must step space twice (further than single step).");
+
+		ps->free_rid(body);
+		ps->free_rid(shape);
+		ps->free_rid(space);
+	}
+
+	// AC8: space_step_batch from non-main thread returns clean error.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_batch from non-main thread returns clean error") {
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		TypedArray<RID> arr;
+		arr.push_back(space);
+
+		struct OffThreadWork {
+			PhysicsServer3D *ps;
+			TypedArray<RID> arr;
+			static void run(void *p_ud) {
+				OffThreadWork *self = static_cast<OffThreadWork *>(p_ud);
+				ERR_PRINT_OFF;
+				self->ps->space_step_batch(self->arr, 1.0f / 60.0f);
+				ERR_PRINT_ON;
+			}
+		} work{ ps, arr };
+
+		WorkerThreadPool::TaskID tid = WorkerThreadPool::get_singleton()->add_native_task(
+				&OffThreadWork::run, &work, false);
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(tid);
+
+		// Server must still be usable from main thread after the no-op off-thread call.
+		CHECK_FALSE(ps->is_flushing_queries());
+		ps->free_rid(space);
+	}
+
+	// AC: space_step_batch does not advance get_physics_frames.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step_batch does not advance physics_frames") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+		TypedArray<RID> arr;
+		arr.push_back(space);
+
+		uint64_t frames_before = Engine::get_singleton()->get_physics_frames();
+		ps->space_step_batch(arr, 1.0f / 60.0f);
+		uint64_t frames_after = Engine::get_singleton()->get_physics_frames();
+
+		CHECK_EQ(frames_before, frames_after);
+		ps->free_rid(space);
+	}
+
 	// AC: space_step called from a non-main thread returns clean error and does not crash.
 	TEST_CASE("[SceneTree][PhysicsServer3D] space_step from non-main thread returns clean error") {
 		if (is_dummy_server()) {
-			WARN("Skipping: dummy physics server has no simulation.");
+			MESSAGE("Skipping: dummy physics server has no simulation.");
 			return;
 		}
 
@@ -520,6 +742,48 @@ TEST_SUITE("[PhysicsServer3D][SpaceStep]") {
 
 		ps->free_rid(body);
 		ps->free_rid(shape);
+		ps->free_rid(space);
+	}
+
+	// #3 delta guard: a non-finite or negative delta must be rejected (no step), not
+	// forwarded to the solver. Covers space_step and, transitively, space_step_safe.
+	TEST_CASE("[SceneTree][PhysicsServer3D] space_step rejects non-finite / negative delta (#3)") {
+		if (is_dummy_server()) {
+			MESSAGE("Skipping: dummy physics server has no simulation.");
+			return;
+		}
+
+		PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
+		REQUIRE(ps != nullptr);
+
+		RID space = ps->space_create();
+		ps->space_set_active(space, true);
+
+		RID sphere_shape = ps->sphere_shape_create();
+		ps->shape_set_data(sphere_shape, 0.5f);
+
+		RID body = ps->body_create();
+		ps->body_set_space(body, space);
+		ps->body_add_shape(body, sphere_shape);
+		ps->body_set_mode(body, PhysicsServer3D::BODY_MODE_RIGID);
+		ps->body_set_state(body, PhysicsServer3D::BODY_STATE_TRANSFORM, Transform3D(Basis(), Vector3(0, 10, 0)));
+
+		const real_t y_start = get_body_y(ps, body);
+
+		// Bad deltas must be rejected (ERR_FAIL), leaving the body untouched.
+		ERR_PRINT_OFF;
+		ps->space_step_safe(space, Math::NaN);
+		ps->space_step_safe(space, Math::INF);
+		ps->space_step_safe(space, -1.0f);
+		ERR_PRINT_ON;
+		CHECK_MESSAGE(get_body_y(ps, body) == y_start, "A non-finite/negative delta must not advance the body.");
+
+		// A valid delta still steps normally (proves the body is otherwise movable).
+		ps->space_step_safe(space, 1.0f / 60.0f);
+		CHECK_MESSAGE(get_body_y(ps, body) < y_start, "A valid delta must still advance the body.");
+
+		ps->free_rid(body);
+		ps->free_rid(sphere_shape);
 		ps->free_rid(space);
 	}
 


### PR DESCRIPTION
## Summary

Phase 5e of the manual physics stepping epic (#1): parallel multi-space stepping. Two deliverables shipped — a **batched contract** that pays the WrapMT main-thread handshake once for N spaces, and a **thread-direct stepping path** that lets a worker thread step an *isolated* Jolt space without the WrapMT command queue. The live-space WrapMT main-thread guard is never relaxed. Batched path is full 2D+3D; the thread-direct path is Jolt-3D-only.

## What changed

- **D1 — `space_step_batch(spaces, delta)`** on `PhysicsServer2D` + `PhysicsServer3D`: a concrete base method composing the existing `space_flush_queries`/`space_step` primitives, with the **WrapMT override owning a single `sync()`/`end_sync()` bracket** so N spaces step inside one rendezvous (serial within). Dummy no-op; GDScript-bound; no GDExtension EXBIND (mirrors `space_step_safe`). Degenerate input is defined: empty → no-op, invalid RID → `ERR_CONTINUE`, duplicates → stepped as given. Contract documented on the class XML.
- **D2 — thread-direct isolated-space stepping (Jolt-3D):** `JoltSpace3D::make_isolated()` swaps the space onto its **own `JPH::JobSystemSingleThreaded` + `JPH::TempAllocatorMalloc`** instead of the server-shared `JoltJobSystem` (whose `Job::completed_head` is a process-wide static) and the shared bump-state temp allocator, removing the cross-space shared mutable state that would race under concurrent `PhysicsSystem::Update`. `JoltPhysicsServer3D::space_make_isolated()` + `space_step_isolated()` expose the path.
- **AC8 guards (all three directions):** `space_step_isolated` rejects non-isolated spaces; `space_make_isolated` rejects spaces already in `active_spaces`; and `space_set_active(true)` rejects an already-isolated space — so a space can never be driven by both the thread-direct path and the main-thread server loop at once.
- **#3 delta guard (operator-requested follow-up):** the manual stepping entry points forwarded a caller-supplied `delta` straight to the solver. Now rejected (`!Math::is_finite || < 0`) at all four entry points across both backends — GodotPhysics 2D/3D + Jolt 3D `space_step` (which also covers `space_step_safe`/`space_step_batch`, as they funnel through it) and Jolt `space_step_isolated` (which bypasses `space_step`, so it carries its own check). The automatic per-frame path is untouched. Regression tests on 3D, 2D, and isolated paths.
- **Build hygiene (operator-requested, pre-existing fixes):** converted `WARN("literal")` → `MESSAGE("literal")` in the physics server test files (space_step/clone/state, 2D+3D) — `doctest::WARN(expr)` is a soft assertion, so `WARN("…")` asserted a string-literal address (a silent runtime no-op **and** a `-Werror=address` break under GCC-15 `warnings=extra`); `MESSAGE()` actually emits the intended skip note. Renamed a local `struct BodyState` in `space_clone_state` → `StagedBodyState` to fix a `-Werror=shadow` of the inherited `PhysicsServer3D::BodyState`. The branch now builds clean under `werror=yes warnings=extra` on GCC-15.

## Acceptance criteria — final state

- ✅ AC1 — Contract documented (class XML; main-thread `ERR_FAIL` rationale).
- ✅ AC2 — `space_step_batch` GDScript-bound 2D+3D; one `sync`/`end_sync` bracket under threaded WrapMT.
- ✅ AC3 — N=4×100 threaded batch-parity harness on AELab `GH-3` within the two-budget tolerance.
- ✅ AC4 — C++ doctest: batch == serial loop (2D+3D).
- ✅ AC5 — No regression; full physics suite green.
- ✅ AC6 — Thread-direct spike validated under TSan (0 races) + ASan (0 heap/leaks), N=4×100 vs same-backend serial oracle.
- ✅ AC7 — Degenerate-input contract (empty/invalid/duplicate).
- ✅ AC8 — Live-space WrapMT guard unchanged; thread-direct path reachable only for isolated spaces; **`space_set_active` symmetric guard** (security F2).

## Operational notes

- The live-space WrapMT main-thread guard on `space_step`/`space_flush_queries`/`space_step_safe`/`space_step_batch` is byte-unchanged. The thread-direct `space_step_isolated` path is reachable **only** for isolated spaces (Phase-4 clone/dry-run spaces, never added to `active_spaces`).
- Callers using physics interpolation still own the flush (Phase-5 precedent); `space_step*` is not coupled to the SceneTree.
- Builds clean under both the regular and `werror=yes warnings=extra` configurations on GCC-15; CI (GCC-11/12) was already unaffected.

## Follow-ups

- [x] **Security F2** (AC8-adjacent): asymmetric `space_set_active` guard — fixed in this PR (`space_set_active(true)` now rejects an isolated space).
- [x] **#3 delta-guard** (security F1): finite/non-negative `delta` guard added at all four manual stepping entry points (2D/3D, both backends) — fixed in this PR. The standing #3 item is now closed for the per-space stepping API. *(The high-level `Engine.physics_iteration` path from Phase 1 is the only remaining `delta`-source not guarded here — separate layer; not part of this surface.)*

_No open follow-ups._

## Links

- Ticket: #15 · Plan: #15 (comment) · Spec: #15 (comment)
- Reviewer verdict: #17 (approve) · Security findings: #17 (comment)
- ADR (thread-direct + per-space JobSystem): #1 (comment)
